### PR TITLE
add noexec for checkmode

### DIFF
--- a/plugins/module_utils/_SqlServerUtils.psm1
+++ b/plugins/module_utils/_SqlServerUtils.psm1
@@ -7,7 +7,7 @@ function Import-ModuleDependency {
     [CmdletBinding()]
     param(
         [System.Version]
-        $MinimumVersion = "1.1.71"
+        $MinimumVersion = "1.1.74"
     )
     try {
         Import-Module -Name "DbaTools" -MinimumVersion $MinimumVersion -DisableNameChecking

--- a/plugins/modules/nonquery.ps1
+++ b/plugins/modules/nonquery.ps1
@@ -41,17 +41,19 @@ $checkMode = $module.CheckMode
 $module.Result.changed = $false
 
 try {
-    if (-not($checkMode)) {
-        $invokeQuerySplat = @{
-            SqlInstance = $sqlInstance
-            SqlCredential = $sqlCredential
-            Database = $database
-            Query = $nonquery
-            QueryTimeout = $queryTimeout
-            EnableException = $true
-        }
-        $null = Invoke-DbaQuery @invokeQuerySplat
+    $invokeQuerySplat = @{
+        SqlInstance = $sqlInstance
+        SqlCredential = $sqlCredential
+        Database = $database
+        Query = $nonquery
+        QueryTimeout = $queryTimeout
+        EnableException = $true
     }
+    if ($checkMode) {
+        $invokeQuerySplat.Add("NoExec", $true)
+    }
+    $null = Invoke-DbaQuery @invokeQuerySplat
+
     $module.Result.changed = $true
     $module.ExitJson()
 }


### PR DESCRIPTION
<!-- markdownlint-disable-file -->
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
When in checkmode, execute the query in NOEXEC mode to get compile and parse checking.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) - Fixes #
- [x] New feature (non-breaking change which adds functionality) - Resolves #18 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/.github/CONTRIBUTING.md) document.
- [ ] I have read/followed the [PR Quick Start Guide](https://github.com/ansible/community-docs/blob/main/create_pr_quick_start_guide.rst)  # TODO: update with link to published doc
- [ ] I have added tests to cover my changes.
