### PR TITLE
docs-build first pass

### DIFF
--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -7,7 +7,14 @@ on:
     branches:
       - main
       - stable-*
+    paths-ignore:
+      - .github/workflows/docs*.yml
+      - .github/workflows/github-release.yml
   pull_request:
+    paths-ignore:
+      - .github/workflows/docs*.yml
+      - .github/workflows/github-release.yml
+
   # Run CI once per day (at 06:00 UTC)
   # This ensures that even if there haven't been commits that we are still testing against latest version of ansible-test for each ansible-base version
   schedule:

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -13,7 +13,14 @@ on:
     branches:
       - main
       - stable-*
+    paths-ignore:
+      - .github/workflows/docs*.yml
+      - .github/workflows/github-release.yml
   pull_request:
+    paths-ignore:
+      - .github/workflows/docs*.yml
+      - .github/workflows/github-release.yml
+
   # Run CI once per day (at 06:00 UTC)
   # This ensures that even if there haven't been commits that we are still testing against latest version of ansible-test for each ansible-base version
   schedule:

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -34,7 +34,8 @@ jobs:
         with:
           collections: lowlydba.sqlserver
           lenient: false
-          fail-on-error: true
+          # fail-on-error: true
+          # ^ this is broken at the moment: https://github.com/ansible-community/antsibull/pull/409
 
       - name: DEBUG
         run: cat "${{ steps.init.outputs.build-script }}"

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -39,9 +39,6 @@ jobs:
           # fail-on-error: true
           # ^ this is broken at the moment: https://github.com/ansible-community/antsibull/pull/409
 
-      - name: DEBUG
-        run: cat "${{ steps.init.outputs.build-script }}"
-
       - name: Build
         id: build
         uses: ansible-community/github-docs-build/actions/ansible-docs-build-html@main

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -36,6 +36,9 @@ jobs:
           lenient: false
           fail-on-error: true
 
+      - name: DEBUG
+        run: cat "${{ steps.init.outputs.build-script }}"
+
       - name: Build
         id: build
         uses: ansible-community/github-docs-build/actions/ansible-docs-build-html@main

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -1,0 +1,85 @@
+name: Collection Docs
+concurrency:
+  group: docs-${{ github.head_ref }}
+  cancel-in-progress: true
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  validate-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    name: Validate Ansible Docs
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Install Ansible
+        run: pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: ansible_collections/lowlydba/sqlserver
+
+      - name: Initialize the build environment
+        id: init
+        uses: ansible-community/github-docs-build/actions/ansible-docs-build-init@main
+        with:
+          collections: lowlydba.sqlserver
+          lenient: false
+          fail-on-error: true
+
+      - name: Build
+        id: build
+        uses: ansible-community/github-docs-build/actions/ansible-docs-build-html@main
+        with:
+          artifact-upload: false
+
+  build-docs:
+    permissions:
+      contents: read
+    name: Build Ansible Docs
+    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-pr.yml@main
+    with:
+      ansible-ref: devel  # TODO: consider milestone
+      init-lenient: true
+      init-fail-on-error: false
+
+  comment:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    needs: [build-docs]
+    name: PR comments
+    steps:
+      - name: PR comment
+        uses: ansible-community/github-docs-build/actions/ansible-docs-build-comment@main
+        with:
+          body-includes: '## Docs Build'
+          reactions: heart
+          action: ${{ needs.build-docs.outputs.changed != 'true' && 'remove' || '' }}
+          on-closed-action: remove
+          on-merged-body: |
+            ## Docs Build 📝
+
+            Thank you for contribution!✨
+
+            This PR has been merged and the docs are now incorporated into `main`.
+          body: |
+            ## Docs Build 📝
+
+            Thank you for contribution!✨
+
+            The docsite for **this PR** is  available for download as an artifact from this run:
+            ${{ needs.build-docs.outputs.artifact-url }}
+
+            File changes:
+
+            ${{ needs.build-docs.outputs.diff-files-rendered }}
+
+            ${{ needs.build-docs.outputs.diff-rendered }}

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -36,8 +36,7 @@ jobs:
         with:
           collections: lowlydba.sqlserver
           lenient: false
-          # fail-on-error: true
-          # ^ this is broken at the moment: https://github.com/ansible-community/antsibull/pull/409
+          fail-on-error: true
 
       - name: Build
         id: build
@@ -51,7 +50,6 @@ jobs:
     name: Build Ansible Docs
     uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-pr.yml@main
     with:
-      ansible-ref: devel  # TODO: consider milestone
       init-lenient: true
       init-fail-on-error: false
 

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: read
     name: Validate Ansible Docs
+    if: github.event.action != 'closed'
     steps:
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -24,6 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
+          ref: refs/pull/${{ github.event.number }}/merge
           path: ansible_collections/lowlydba/sqlserver
 
       - name: Initialize the build environment

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -12,6 +12,8 @@ jobs:
     permissions:
       contents: read
     name: Validate Ansible Docs
+    env:
+      ANSIBLE_COLLECTIONS_PATHS: ${{ github.workspace }}
     if: github.event.action != 'closed'
     steps:
       - name: Set up Python

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -16,7 +16,5 @@ jobs:
     name: Build Ansible Docs
     uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-push.yml@main
     with:
-      ansible-ref: devel  # TODO: consider milestone
       init-lenient: false
-      # init-fail-on-error: true
-      # ^ this is broken at the moment: https://github.com/ansible-community/antsibull/pull/409
+      init-fail-on-error: true

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -19,4 +19,5 @@ jobs:
     with:
       ansible-ref: devel  # TODO: consider milestone
       init-lenient: false
-      init-fail-on-error: true
+      # init-fail-on-error: true
+      # ^ this is broken at the moment: https://github.com/ansible-community/antsibull/pull/409

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -4,8 +4,9 @@ concurrency:
   cancel-in-progress: true
 on:
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
+    # DISABLE BRANCH TARGETING FOR TESTING
   schedule:
     - cron: '0 13 * * *'
 

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -4,9 +4,8 @@ concurrency:
   cancel-in-progress: true
 on:
   push:
-    # branches:
-    #   - main
-    # DISABLE BRANCH TARGETING FOR TESTING
+    branches:
+      - main
   schedule:
     - cron: '0 13 * * *'
 

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -1,0 +1,21 @@
+name: Collection Docs
+concurrency:
+  group: docs-${{ github.sha }}
+  cancel-in-progress: true
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 13 * * *'
+
+jobs:
+  build-docs:
+    permissions:
+      contents: read
+    name: Build Ansible Docs
+    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-push.yml@main
+    with:
+      ansible-ref: devel  # TODO: consider milestone
+      init-lenient: false
+      init-fail-on-error: true


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Adding docs builds on push and PR. There's no publish step yet for these, so this does the following for now:
* on push: ensures docs can be built without errors
* on PR:
  * ensures docs build without errors
  * performs a lenient build on both the PR base and target, compares them, and if there are differences, posts a comment on the PR highlighting the differences
  * when a publishing step is included (future), the comment can include links to these pages
  * the built docsite can be downloaded from the build artifacts to be inspected locally

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
UPDATE on below:
- PR flows tested in #41 
- Push tested in https://github.com/lowlydba/lowlydba.sqlserver/actions/runs/2045703922

----

The push workflow only triggers on pushes to `main`, and the PR workflow uses the `pull_request_target` event which means that the workflow itself is always loaded from the target branch, not from the PR contents.

As a result, the `push` workflow can't be tested without either merging first, or changing the target branch in the PR and then changing it back.

For `pull_request_target` workflows, the PR introducing it or changing it must be pushed to a branch on the main repo, not on a fork, and then a test PR can be opened (from a fork or the main repo) against that branch, in order to trigger the workflow.

So I'm putting this up as is, not from a fork, and I will open a test PR for the latter case.

I may also mess with the branch filter on the push workflow to try to test that.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/.github/CONTRIBUTING.md) document.
- [X] I have read/followed the [PR Quick Start Guide](https://github.com/ansible/community-docs/blob/main/create_pr_quick_start_guide.rst)  # TODO: update with link to published doc
- [X] I have added tests to cover my changes or they are N/A.
- [X] New module options/parameters include a [`version_added` property](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fields).
