### PR TITLE
add GH release workflow

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,65 @@
+name: GitHub Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number to release'
+        required: true
+
+jobs:
+
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install PyYaml
+        run: pip install pyyaml
+
+      - name: Validate version is published to Galaxy
+        run: curl --head -s -f -o /dev/null https://galaxy.ansible.com/download/lowlydba-sqlserver-${{ github.event.inputs.version }}.tar.gz
+
+      - name: Build release description
+        shell: python
+        run: |
+          import os
+          import yaml
+
+          ver = '${{ github.event.inputs.version }}'
+          ver_anchor = str.replace(ver, '.', '-')
+
+          with open('changelogs/changelog.yaml', 'r') as s:
+              ri = yaml.safe_load(s)
+
+          summary = ri['releases'][ver]['changes']['release_summary']
+          reldate = ri['releases'][ver]['release_date']
+
+          description = '''## Summary
+          Released: %s
+
+          %s
+
+          ---
+
+          View the [complete changelog](https://github.com/lowlydba/lowlydba.sqlserver/blob/main/CHANGELOG.rst#v%s) to see all changes.
+          ''' % (reldate, summary, ver_anchor)
+
+          with open(os.environ['GITHUB_ENV'], 'a') as e:
+              e.write("RELEASE_DESCRIPTION<<EOF\n%s\nEOF" % description)
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.version }}
+          release_name: ${{ github.event.inputs.version }}
+          body: ${{ env.RELEASE_DESCRIPTION }}


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
A way to create a nice GitHub release easily, after the actual release process.
It's a manual run, to be done after it's published to galaxy.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
community.hashi_vault

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) - Fixes #
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/.github/CONTRIBUTING.md) document.
- [x] I have read/followed the [PR Quick Start Guide](https://github.com/ansible/community-docs/blob/main/create_pr_quick_start_guide.rst)  # TODO: update with link to published doc
- [x] I have added tests to cover my changes or they are N/A.
- [ ] New module options/parameters include a [`version_added` property](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fields).
