### PR TITLE
agent_job_step: allow step dropping with id only

### DIFF
--- a/changelogs/fragments/95-fix-agent-job-step-removal.yml
+++ b/changelogs/fragments/95-fix-agent-job-step-removal.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Allow agent job steps to be removed by specifying the step ID only.
+    This is likely needed in cleanup of steps from previous job configurations.

--- a/plugins/modules/agent_job_step.ps1
+++ b/plugins/modules/agent_job_step.ps1
@@ -106,7 +106,7 @@ try {
         }
     }
     elseif ($state -eq "present") {
-        if !($stepName) {
+        if (!($stepName)) {
             $module.FailJson("Step name must be specified when state=present.")
         }
         # No existing job step

--- a/plugins/modules/agent_job_step.ps1
+++ b/plugins/modules/agent_job_step.ps1
@@ -90,6 +90,7 @@ try {
         if ($null -eq $existingJobStep) {
             # try fetching by id only
             $existingJobStep = $existingJobSteps | Where-Object Id -eq $stepId
+            $stepName = $existingJobStep.Name
         }
         if ($existingJobStep) {
             $removeStepSplat = @{

--- a/plugins/modules/agent_job_step.ps1
+++ b/plugins/modules/agent_job_step.ps1
@@ -38,7 +38,7 @@ $spec = @{
         , @('retry_attempts', 'retry_interval')
     )
     required_one_of = @(
-        , @('step_id',  'step_name')
+        , @('step_id', 'step_name')
     )
 }
 

--- a/plugins/modules/agent_job_step.py
+++ b/plugins/modules/agent_job_step.py
@@ -25,8 +25,8 @@ options:
     type: int
   step_name:
     description:
-      - The name of the step.
-    required: true
+      - The name of the step. Required if I(state=present).
+    required: false
     type: str
   database:
     description:

--- a/tests/integration/targets/agent_job_step/tasks/main.yml
+++ b/tests/integration/targets/agent_job_step/tasks/main.yml
@@ -124,7 +124,7 @@
 
     - name: Remove agent job step in checkmode
       lowlydba.sqlserver.agent_job_step:
-        step_name: "{{ job_step2 }}"
+        step_id: 2
         state: "absent"
       check_mode: true
       register: result
@@ -134,7 +134,7 @@
 
     - name: Verify remove agent job step in checkmode works
       lowlydba.sqlserver.agent_job_step:
-        step_name: "{{ job_step2 }}"
+        step_id: 2
         state: "absent"
       register: result
     - assert:


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Allow job steps to be dropped from ID only, not by name.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Incorporated this into the existing int tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) - Fixes #94 
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/.github/CONTRIBUTING.md) document.
- [x] I have read/followed the [PR Quick Start Guide](https://github.com/ansible/community-docs/blob/main/create_pr_quick_start_guide.rst)  # TODO: update with link to published doc
- [x] I have added tests to cover my changes or they are N/A.
- [x] New module options/parameters include a [`version_added` property](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fields).
