### PR TITLE
Corrected how resource governor classifier name is being assigned to …

### DIFF
--- a/changelogs/fragments/resource_governor.yml
+++ b/changelogs/fragments/resource_governor.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fixed bug in how the classifier function name is being assigned to the variable in the resource_governor module.

--- a/plugins/modules/resource_governor.ps1
+++ b/plugins/modules/resource_governor.ps1
@@ -30,7 +30,7 @@ $PSDefaultParameterValues = @{ "*:EnableException" = $true; "*:Confirm" = $false
 
 try {
     $rg = Get-DbaResourceGovernor -SqlInstance $sqlInstance -SqlCredential $sqlCredential
-    $rgClassifierFunction = $rg.ClassifierFunction.Name
+    $rgClassifierFunction = $rg.ClassifierFunction
 
     if ($rg.Enabled -ne $enabled) {
         $change = $true


### PR DESCRIPTION

<!-- markdownlint-disable-file -->

## Description
<!--- Describe your changes in detail -->
Corrected how resource governor classifier name is being assigned to the variable. 

<!--- Why is this change required? What problem does it solve? -->
It throws an error when trying to  assign NULL value to the classifier function name.  The classifier name can be retrieved from $rg.ClassifierFunction.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Yes, it was tested locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) - Fixes #
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/.github/CONTRIBUTING.md) document.
- [ ] I have read/followed the [PR Quick Start Guide](https://docs.ansible.com/ansible/devel/community/create_pr_quick_start.html)
- [ ] I have added tests to cover my changes or they are N/A.
- [ ] New module options/parameters include a [`version_added` property](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fields).
