### PR TITLE
feature: sql mi compatibility

### DIFF
--- a/changelogs/fragments/xpdirtree_sql_mi_bugfix.yml
+++ b/changelogs/fragments/xpdirtree_sql_mi_bugfix.yml
@@ -1,0 +1,2 @@
+- bugfixes:
+  - Removed the default value for xp_dirtree to allow compatibility with Azure SQL Mangaed instances

--- a/changelogs/fragments/xpdirtree_sql_mi_bugfix.yml
+++ b/changelogs/fragments/xpdirtree_sql_mi_bugfix.yml
@@ -1,2 +1,2 @@
-- bugfixes:
+bugfixes:
   - Removed the default value for xp_dirtree to allow compatibility with Azure SQL Mangaed instances

--- a/plugins/modules/restore.ps1
+++ b/plugins/modules/restore.ps1
@@ -90,7 +90,6 @@ try {
         Path = $path
         WithReplace = $withReplace
         KeepReplication = $keepReplication
-        XpDirTree = $xpDirTree
         NoXpDirRecurse = $noXpDirRecurse
         VerifyOnly = $verifyOnly
         MaintenanceSolutionBackup = $maintenanceSolutionBackup
@@ -143,6 +142,9 @@ try {
     }
     if ($null -ne $azureCredential) {
         $restoreSplat.Add("AzureCredential", $azureCredential)
+    }
+    if ($null -ne $xpDirTree) {
+        $restoreSplat.Add("xpDirTree", $xpDirTree)
     }
     $output = Restore-DbaDatabase @restoreSplat
 

--- a/plugins/modules/restore.ps1
+++ b/plugins/modules/restore.ps1
@@ -21,7 +21,7 @@ $spec = @{
         restore_time = @{type = 'str'; required = $false }
         with_replace = @{type = 'bool'; required = $false; default = $false }
         keep_replication = @{type = 'bool'; required = $false; default = $false }
-        xp_dirtree = @{type = 'bool'; required = $false; default = $false }
+        xp_dirtree = @{type = 'bool'; required = $false }
         no_xp_dir_recurse = @{type = 'bool'; required = $false; default = $false }
         verify_only = @{type = 'bool'; required = $false; default = $false }
         maintenance_solution_backup = @{type = 'bool'; required = $false; default = $false }

--- a/plugins/modules/restore.py
+++ b/plugins/modules/restore.py
@@ -67,7 +67,6 @@ options:
       - You must have sysadmin role membership on the instance for this to work.
     type: bool
     required: false
-    default: false
   no_xp_dir_recurse:
     description:
       - If specified, prevents the C(XpDirTree) process from recursing (its default behaviour).


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

## Description
Remove the default option for xpDirTree to allow for compatibility with Azure SQL MI

## How Has This Been Tested?
Not tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) - Fixes #
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/CONTRIBUTING.md) document.
- [x] I have read/followed the [PR Quick Start Guide](https://docs.ansible.com/ansible/devel/community/create_pr_quick_start.html)
- [x] I have added tests to cover my changes or they are N/A.
- [ ] New module options/parameters include a [`version_added` property](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fields).
