### PR TITLE
Feature/sql mi fix

### DIFF
--- a/changelogs/fragments/reuse_source_folder_structure_sql_mi_bugfix.yml
+++ b/changelogs/fragments/reuse_source_folder_structure_sql_mi_bugfix.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Removed default value for reuse_source_folder_structure to fix compatability with SQL MI
+  - Removed default value for reuse_source_folder_structure to fix compatability with SQL MI (https://github.com/lowlydba/lowlydba.sqlserver/pull/145)

--- a/changelogs/fragments/reuse_source_folder_structure_sql_mi_bugfix.yml
+++ b/changelogs/fragments/reuse_source_folder_structure_sql_mi_bugfix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Removed default value for reuse_source_folder_structure to fix compatability with SQL MI

--- a/plugins/modules/restore.ps1
+++ b/plugins/modules/restore.ps1
@@ -28,7 +28,7 @@ $spec = @{
         ignore_log_backup = @{type = 'bool'; required = $false; default = $false }
         ignore_diff_backup = @{type = 'bool'; required = $false; default = $false }
         use_destination_default_directories = @{type = 'bool'; required = $false; default = $false }
-        reuse_source_folder_structure = @{type = 'bool'; required = $false; default = $false }
+        reuse_source_folder_structure = @{type = 'bool'; required = $false }
         destination_file_prefix = @{type = 'str'; required = $false }
         restored_database_name_prefix = @{type = 'str'; required = $false }
         directory_recurse = @{type = 'bool'; required = $false; default = $false }
@@ -95,7 +95,6 @@ try {
         MaintenanceSolutionBackup = $maintenanceSolutionBackup
         IgnoreLogBackup = $ignoreLogBackup
         IgnoreDiffBackup = $ignoreDiffBackup
-        ReuseSourceFolderStructure = $reuseSourceFolderStructure
         DirectoryRecurse = $directoryRecurse
         ReplaceDbNameInFile = $replaceDbNameInFile
         KeepCDC = $keepCDC
@@ -145,6 +144,9 @@ try {
     }
     if ($null -ne $xpDirTree) {
         $restoreSplat.Add("xpDirTree", $xpDirTree)
+    }
+    if ($null -ne $reuseSourceFolderStructure) {
+        $restoreSplat.Add("reuseSourceFolderStructure", $reuseSourceFolderStructure)
     }
     $output = Restore-DbaDatabase @restoreSplat
 

--- a/plugins/modules/restore.py
+++ b/plugins/modules/restore.py
@@ -111,7 +111,6 @@ options:
       - You can override this by using C(reuse_source_folder_structure).
     type: bool
     required: false
-    default: false
   destination_file_prefix:
     description:
       - This value will be prefixed to B(all) restored files (log and data).


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

## Description
Remove the default option for reuse_source_folder_structure to allow for compatibility with Azure SQL MI

## How Has This Been Tested?
Not tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) - Fixes #
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/CONTRIBUTING.md) document.
- [x] I have read/followed the [PR Quick Start Guide](https://docs.ansible.com/ansible/devel/community/create_pr_quick_start.html)
- [x] I have added tests to cover my changes or they are N/A.
- [ ] New module options/parameters include a [`version_added` property](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fields).