### PR TITLE
Fix/sql mi fix

### DIFF
--- a/changelogs/fragments/ReplaceDbNameInFile_sql_mi_bugfix
+++ b/changelogs/fragments/ReplaceDbNameInFile_sql_mi_bugfix
@@ -1,0 +1,2 @@
+bugfixes:
+  - Removed default value for ReplaceDbNameInFile to fix compatability with SQL MI

--- a/changelogs/fragments/ReplaceDbNameInFile_sql_mi_bugfix
+++ b/changelogs/fragments/ReplaceDbNameInFile_sql_mi_bugfix
@@ -1,2 +1,0 @@
-bugfixes:
-  - Removed default value for ReplaceDbNameInFile to fix compatability with SQL MI

--- a/changelogs/fragments/ReplaceDbNameInFile_sql_mi_bugfix.yml
+++ b/changelogs/fragments/ReplaceDbNameInFile_sql_mi_bugfix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Removed default value for ReplaceDbNameInFile to fix compatability with SQL MI (https://github.com/lowlydba/lowlydba.sqlserver/pull/148)

--- a/plugins/modules/restore.ps1
+++ b/plugins/modules/restore.ps1
@@ -33,7 +33,7 @@ $spec = @{
         restored_database_name_prefix = @{type = 'str'; required = $false }
         directory_recurse = @{type = 'bool'; required = $false; default = $false }
         standby_directory = @{type = 'str'; required = $false }
-        replace_db_name_in_file = @{type = 'bool'; required = $false; default = $false }
+        replace_db_name_in_file = @{type = 'bool'; required = $false }
         destination_file_suffix = @{type = 'str'; required = $false }
         keep_cdc = @{type = 'bool'; required = $false; default = $false }
         stop_before = @{type = 'bool'; required = $false; default = $false }
@@ -96,7 +96,6 @@ try {
         IgnoreLogBackup = $ignoreLogBackup
         IgnoreDiffBackup = $ignoreDiffBackup
         DirectoryRecurse = $directoryRecurse
-        ReplaceDbNameInFile = $replaceDbNameInFile
         KeepCDC = $keepCDC
         StopBefore = $stopBefore
         NoRecovery = $noRecovery
@@ -147,6 +146,9 @@ try {
     }
     if ($null -ne $reuseSourceFolderStructure) {
         $restoreSplat.Add("reuseSourceFolderStructure", $reuseSourceFolderStructure)
+    }
+    if ($null -ne $replaceDbNameInFile) {
+        $restoreSplat.Add("replaceDbNameInFile", $replaceDbNameInFile)
     }
     $output = Restore-DbaDatabase @restoreSplat
 

--- a/plugins/modules/restore.py
+++ b/plugins/modules/restore.py
@@ -139,7 +139,6 @@ options:
         will be replace with the name specified in the I(database_name) option.
     type: bool
     required: false
-    default: false
   destination_file_suffix:
     description:
       - This value will be suffixed to B(all) restored files (log and data).


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

## Description
Remove the default option for replace_db_name_in_file to allow for compatibility with Azure SQL MI

## How Has This Been Tested?
Not tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) - Fixes #
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/CONTRIBUTING.md) document.
- [x] I have read/followed the [PR Quick Start Guide](https://docs.ansible.com/ansible/devel/community/create_pr_quick_start.html)
- [x] I have added tests to cover my changes or they are N/A.
- [ ] New module options/parameters include a [`version_added` property](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fields).