### PR TITLE
fix: mismatched param in example

### DIFF
--- a/changelogs/fragments/fix_doc_example.yml
+++ b/changelogs/fragments/fix_doc_example.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fixes mismatched parameters in the credential documentation

--- a/plugins/modules/credential.py
+++ b/plugins/modules/credential.py
@@ -61,7 +61,7 @@ EXAMPLES = r'''
     sql_instance: sql-01.myco.io
     identity: ad\\user
     name: MyCredential
-    secure_password : <Password>
+    password : <Password>
 
 - name: Replace an existing credential
   lowlydba.sqlserver.credential:
@@ -74,7 +74,7 @@ EXAMPLES = r'''
     sql_instance: sql-01.myco.io
     identity: SHARED ACCESS SIGNATURE
     name: https://<azure storage account name>.blob.core.windows.net/<blob container>
-    secure_password : <Shared Access Token>
+    password : <Shared Access Token>
 
 - name: Remove a credential
   lowlydba.sqlserver.credential:


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

## Description
Fixes an error in the examples in the credential documentation

## How Has This Been Tested?
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) - Fixes #
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/CONTRIBUTING.md) document.
- [x] I have read/followed the [PR Quick Start Guide](https://docs.ansible.com/ansible/devel/community/create_pr_quick_start.html)
- [x] I have added tests to cover my changes or they are N/A.
- [x] I have added a [changelog fragment](https://github.com/ansible-community/antsibull-changelog/blob/main/docs/changelogs.rst#changelog-fragment-categories) describing the changes.
- [ ] New module options/parameters include a [`version_added` property](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fields).
