### PR TITLE
fix: change $sa to $existingLogin

### DIFF
--- a/changelogs/fragments/fix_doc_example.yml
+++ b/changelogs/fragments/fix_doc_example.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - Fixes mismatched parameters in the credential documentation

--- a/changelogs/fragments/fix_sa.yml
+++ b/changelogs/fragments/fix_sa.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Fixes to incorrect variable reference in Login module
+  - Fixes to incorrect variable reference in Login module (https://github.com/lowlydba/lowlydba.sqlserver/pull/161)

--- a/changelogs/fragments/fix_sa.yml
+++ b/changelogs/fragments/fix_sa.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fixes to incorrect variable reference in Login module

--- a/plugins/modules/login.ps1
+++ b/plugins/modules/login.ps1
@@ -71,7 +71,7 @@ try {
             $setLoginSplat.add("DefaultDatabase", $defaultDatabase)
         }
         if ($null -ne $passwordExpirationEnabled) {
-            if ($sa.PasswordExpirationEnabled -ne $passwordExpirationEnabled) {
+            if ($existingLogin.PasswordExpirationEnabled -ne $passwordExpirationEnabled) {
                 $changed = $true
             }
             if ($passwordExpirationEnabled -eq $true) {
@@ -79,7 +79,7 @@ try {
             }
         }
         if ($null -ne $passwordPolicyEnforced) {
-            if ($sa.PasswordPolicyEnforced -ne $passwordPolicyEnforced) {
+            if ($existingLogin.PasswordPolicyEnforced -ne $passwordPolicyEnforced) {
                 $changed = $true
             }
             if ($passwordPolicyEnforced -eq $true) {
@@ -87,7 +87,7 @@ try {
             }
         }
         if ($true -eq $passwordMustChange) {
-            if ($sa.PasswordMustChange -ne $passwordMustChange) {
+            if ($existingLogin.PasswordMustChange -ne $passwordMustChange) {
                 $changed = $true
             }
             if ($passwordMustChange -eq $true) {
@@ -109,7 +109,7 @@ try {
                 $setLoginSplat.add("Enable", $true)
             }
             # Login needs to be modified
-            if (($changed -eq $true) -or ($disabled -ne $sa.IsDisabled) -or ($secPassword)) {
+            if (($changed -eq $true) -or ($disabled -ne $existingLogin.IsDisabled) -or ($secPassword)) {
                 $output = Set-DbaLogin @setLoginSplat
                 $module.result.changed = $true
             }


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

## Description
Changed incorrect references of $sa variable to $existingLogin in Login.ps1.  Bug described in #159 

## How Has This Been Tested?
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) - Fixes #
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/CONTRIBUTING.md) document.
- [x] I have read/followed the [PR Quick Start Guide](https://docs.ansible.com/ansible/devel/community/create_pr_quick_start.html)
- [x] I have added tests to cover my changes or they are N/A.
- [x] I have added a [changelog fragment](https://github.com/ansible-community/antsibull-changelog/blob/main/docs/changelogs.rst#changelog-fragment-categories) describing the changes.
- [ ] New module options/parameters include a [`version_added` property](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fields).
