### PR TITLE
chores: add win ci retry for coll dependency

### DIFF
--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -160,6 +160,12 @@ jobs:
           python3 -m pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check --retries 10
 
       - name: Install collection dependencies
+        id: collection-dependency
+        run: ansible-galaxy collection install ansible.windows -p "${{ env.GHWS }}"
+        continue-on-error: true
+
+      - name: Retry install collection dependencies
+        if: steps.collection-dependency.outcome == 'failure'
         run: ansible-galaxy collection install ansible.windows -p "${{ env.GHWS }}"
 
       - name: Set integration test options


### PR DESCRIPTION
Add a retry when trying to install collection dependencies, since Galaxy can be pretty flakey.

Fixes #165 