### PR TITLE
chores: stagger win ci schedule

### DIFF
--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -22,7 +22,7 @@ on:
   # Run CI once per day (at 06:00 UTC)
   # This ensures that even if there haven't been commits that we are still testing against latest version of ansible-test for each ansible-base version
   schedule:
-    - cron: "0 6 * * *"
+    - cron: "0 8 * * *"
 
 # Cancel existing runs on new commits to a branch
 concurrency:


### PR DESCRIPTION
As recommended by Github support, since our calls to install sp_whoisactive are unauthenticated the CI is triggering rate limits (60/hr) so staggering the Windows CI may help alleviate this.