### PR TITLE
chores: remove core 2.11 support/testing

### DIFF
--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -49,7 +49,6 @@ jobs:
         os:
           - windows-2022
         ansible:
-          - stable-2.11
           - stable-2.12
           - stable-2.13
           - stable-2.14

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -52,7 +52,6 @@ jobs:
         ansible:
           # It's important that Sanity is tested against all stable-X.Y branches
           # Testing against `devel` may fail as new tests are added.
-          - stable-2.11
           - stable-2.12
           - stable-2.13
           - stable-2.14
@@ -119,7 +118,6 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.11
           - stable-2.12
           - stable-2.13
           - stable-2.14

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ To learn how to maintain / become a maintainer of this collection, refer to the 
 
 ### Ansible
 
-- 2.11
 - 2.12
 - 2.13
 - 2.14

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.11"
+requires_ansible: ">=2.12"


### PR DESCRIPTION
Since 2.11 is [EOL](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html) we don't need to be running tests against it. 