### PR TITLE
Issue-189: Add sid as a optional parameter for login module

### DIFF
--- a/changelogs/fragments/189-add-sid-to-login.yml
+++ b/changelogs/fragments/189-add-sid-to-login.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Added SID as an optional parameter to the login module (https://github.com/lowlydba/lowlydba.sqlserver/pull/189)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: lowlydba
 name: sqlserver
-version: 2.0.2
+version: 2.0.1
 readme: README.md
 authors:
   - John McCall (github.com/lowlydba)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: lowlydba
 name: sqlserver
-version: 2.0.0
+version: 2.0.1
 readme: README.md
 authors:
   - John McCall (github.com/lowlydba)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: lowlydba
 name: sqlserver
-version: 2.0.1
+version: 2.0.2
 readme: README.md
 authors:
   - John McCall (github.com/lowlydba)

--- a/plugins/modules/login.ps1
+++ b/plugins/modules/login.ps1
@@ -22,7 +22,6 @@ $spec = @{
         password_policy_enforced = @{type = 'bool'; required = $false }
         password_expiration_enabled = @{type = 'bool'; required = $false }
         sid = @{type = 'str'; required = $false }
-        skip_password_reset = @{type = 'bool'; required = $false }
         state = @{type = 'str'; required = $false; default = 'present'; choices = @('present', 'absent') }
     }
 }
@@ -39,7 +38,6 @@ $language = $module.Params.language
 [nullable[bool]]$passwordMustChange = $module.Params.password_must_change
 [nullable[bool]]$passwordExpirationEnabled = $module.Params.password_expiration_enabled
 [nullable[bool]]$passwordPolicyEnforced = $module.Params.password_policy_enforced
-[nullable[bool]]$skip_password_reset = $module.Params.skip_password_reset
 $sid = $module.Params.sid
 $state = $module.Params.state
 $checkMode = $module.CheckMode

--- a/plugins/modules/login.ps1
+++ b/plugins/modules/login.ps1
@@ -22,6 +22,7 @@ $spec = @{
         password_policy_enforced = @{type = 'bool'; required = $false }
         password_expiration_enabled = @{type = 'bool'; required = $false }
         sid = @{type = 'str'; required = $false }
+        skip_password_reset = @{type = 'bool'; required = $false }
         state = @{type = 'str'; required = $false; default = 'present'; choices = @('present', 'absent') }
     }
 }
@@ -38,6 +39,7 @@ $language = $module.Params.language
 [nullable[bool]]$passwordMustChange = $module.Params.password_must_change
 [nullable[bool]]$passwordExpirationEnabled = $module.Params.password_expiration_enabled
 [nullable[bool]]$passwordPolicyEnforced = $module.Params.password_policy_enforced
+[nullable[bool]]$skip_password_reset = $module.Params.skip_password_reset
 $sid = $module.Params.sid
 $state = $module.Params.state
 $checkMode = $module.CheckMode

--- a/plugins/modules/login.ps1
+++ b/plugins/modules/login.ps1
@@ -21,6 +21,7 @@ $spec = @{
         password_must_change = @{type = 'bool'; required = $false }
         password_policy_enforced = @{type = 'bool'; required = $false }
         password_expiration_enabled = @{type = 'bool'; required = $false }
+        sid = @{type = 'str'; required = $false }
         state = @{type = 'str'; required = $false; default = 'present'; choices = @('present', 'absent') }
     }
 }
@@ -37,6 +38,7 @@ $language = $module.Params.language
 [nullable[bool]]$passwordMustChange = $module.Params.password_must_change
 [nullable[bool]]$passwordExpirationEnabled = $module.Params.password_expiration_enabled
 [nullable[bool]]$passwordPolicyEnforced = $module.Params.password_policy_enforced
+$sid = $module.Params.sid
 $state = $module.Params.state
 $checkMode = $module.CheckMode
 
@@ -121,6 +123,9 @@ try {
             }
             if ($enabled -eq $false) {
                 $setLoginSplat.add("Disabled", $true)
+            }
+            if ($null -ne $sid) {
+                $setLoginSplat.add("Sid", $sid)
             }
             $output = New-DbaLogin @setLoginSplat
             $module.result.changed = $true

--- a/plugins/modules/login.py
+++ b/plugins/modules/login.py
@@ -61,6 +61,12 @@ options:
     type: str
     required: false
     version_added: '2.0.1'
+  skip_password_reset:
+    description:
+      - Skips the password reset if the login exists and I(password) is set.
+    type: bool
+    required: false
+    version_added: '2.0.2'
 author: "John McCall (@lowlydba)"
 notes:
   - Module will always return changed if a password is supplied.

--- a/plugins/modules/login.py
+++ b/plugins/modules/login.py
@@ -61,12 +61,6 @@ options:
     type: str
     required: false
     version_added: '2.0.1'
-  skip_password_reset:
-    description:
-      - Skips the password reset if the login exists and I(password) is set.
-    type: bool
-    required: false
-    version_added: '2.0.2'
 author: "John McCall (@lowlydba)"
 notes:
   - Module will always return changed if a password is supplied.

--- a/plugins/modules/login.py
+++ b/plugins/modules/login.py
@@ -55,6 +55,12 @@ options:
       - Enforces password expiration policy. Requires I(password_policy_enforced=true).
     type: bool
     required: false
+  sid:
+    description:
+      - Provide an explicit Sid that should be used when creating the account.
+    type: str
+    required: false
+    version_added: '2.0.1'
 author: "John McCall (@lowlydba)"
 notes:
   - Module will always return changed if a password is supplied.

--- a/tests/integration/targets/login/tasks/main.yml
+++ b/tests/integration/targets/login/tasks/main.yml
@@ -6,6 +6,7 @@
     password_expiration_enabled: false
     password_policy_enforced: false
     password_must_change: false
+    sid: "0x918315B409D64E4BABB31DF2D9FEA879"
     enabled: false
     default_database: "master"
     language: "us_english"
@@ -19,6 +20,7 @@
       password: "{{ plain_password }}"
       password_expiration_enabled: "{{ password_expiration_enabled }}"
       password_must_change: "{{ password_must_change }}"
+      sid: "{{ sid }}"
       enabled: "{{ enabled }}"
       language: "{{ language }}"
       state: present


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

## Description
SQL Logins for always on instances require that the SID match across all nodes in the cluster. DBAtools already supports the sid parameter so just adding it as an optional parameter.

Fixes lowlydba/lowlydba.sqlserver#189

## How Has This Been Tested?
Add sid to the integration test for login.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) - Fixes #
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/CONTRIBUTING.md) document.
- [x] I have read/followed the [PR Quick Start Guide](https://docs.ansible.com/ansible/devel/community/create_pr_quick_start.html)
- [x] I have added tests to cover my changes or they are N/A.
- [x] I have added a [changelog fragment](https://github.com/ansible-community/antsibull-changelog/blob/main/docs/changelogs.rst#changelog-fragment-categories) describing the changes.
- [x] New module options/parameters include a [`version_added` property](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fields).
