### PR TITLE
Fixes #198, adds param to support removing inaccessible databases

### DIFF
--- a/changelogs/fragments/198-add-onlyaccessible-param-to-database.yml
+++ b/changelogs/fragments/198-add-onlyaccessible-param-to-database.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Added only_accessible as an optional parameter to the database module (https://github.com/lowlydba/lowlydba.sqlserver/pull/198)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: lowlydba
 name: sqlserver
-version: 2.1.0
+version: 2.2.0
 readme: README.md
 authors:
   - John McCall (github.com/lowlydba)

--- a/plugins/modules/database.ps1
+++ b/plugins/modules/database.ps1
@@ -22,6 +22,7 @@ $spec = @{
         secondary_maxdop = @{type = 'int'; required = $false; }
         compatibility = @{type = 'str'; required = $false; }
         rcsi = @{type = 'bool'; required = $false; }
+        only_accessible = @{type = 'bool'; default = 'true' }
         state = @{type = 'str'; required = $false; default = 'present'; choices = @('present', 'absent') }
     }
 }
@@ -35,6 +36,7 @@ $logFilePath = $module.Params.log_file_path
 $owner = $module.Params.owner
 $compatibility = $module.Params.compatibility
 [nullable[bool]]$rcsiEnabled = $module.Params.rcsi
+[nullable[bool]]$onlyAccessible = $module.Params.only_accessible
 [nullable[int]]$maxDop = $module.Params.maxdop
 [nullable[int]]$secondaryMaxDop = $module.Params.secondary_maxdop
 $state = $module.Params.state
@@ -48,7 +50,7 @@ try {
             SqlInstance = $sqlInstance
             SqlCredential = $sqlCredential
             Database = $database
-            OnlyAccessible = $true
+            OnlyAccessible = $onlyAccessible
             ExcludeSystem = $true
             EnableException = $true
         }

--- a/plugins/modules/database.py
+++ b/plugins/modules/database.py
@@ -61,6 +61,12 @@ options:
       - Whether or not to enable Read Committed Snapshot Isolation.
     required: false
     type: bool
+  only_accessible:
+    description:
+      - Whether or not to enable Read Committed Snapshot Isolation.
+    default: true
+    required: false
+    type: bool
 author: "John McCall (@lowlydba)"
 requirements:
   - L(dbatools,https://www.powershellgallery.com/packages/dbatools/) PowerShell module

--- a/plugins/modules/database.py
+++ b/plugins/modules/database.py
@@ -67,6 +67,7 @@ options:
     default: true
     required: false
     type: bool
+    version_added: '2.2.0'
 author: "John McCall (@lowlydba)"
 requirements:
   - L(dbatools,https://www.powershellgallery.com/packages/dbatools/) PowerShell module


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Adds _only_accessible_ parameter to module to support removing orphaned database on availability group replica.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Local testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) - Fixes #198 
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/CONTRIBUTING.md) document.
- [x] I have read/followed the [PR Quick Start Guide](https://docs.ansible.com/ansible/devel/community/create_pr_quick_start.html)
- [x] I have added tests to cover my changes or they are N/A.
This may be difficult to emulate with current infrastructure.
- [x] I have added a [changelog fragment](https://github.com/ansible-community/antsibull-changelog/blob/main/docs/changelogs.rst#changelog-fragment-categories) describing the changes.
- [x] New module options/parameters include a [`version_added` property](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fields).
