### PR TITLE
fix: refer to portnumber property correctly

### DIFF
--- a/changelogs/fragments/209-fix-port-ref.yml
+++ b/changelogs/fragments/209-fix-port-ref.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Get port properly from AG Listener when comparing to input port value.

--- a/changelogs/fragments/release-summary-2-2-2.yml
+++ b/changelogs/fragments/release-summary-2-2-2.yml
@@ -1,0 +1,1 @@
+release_summary: Minor bugfix for setting the port on an AG listener.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: lowlydba
 name: sqlserver
-version: 2.2.1
+version: 2.2.2
 readme: README.md
 authors:
   - John McCall (github.com/lowlydba)

--- a/plugins/modules/ag_listener.ps1
+++ b/plugins/modules/ag_listener.ps1
@@ -63,7 +63,7 @@ try {
             $output = Add-DbaAgListener @listenerParams
             $module.Result.changed = $true
         }
-        elseif ($existingListener.Port -ne $port) {
+        elseif ($existingListener.PortNumber -ne $port) {
             $output = Set-DbaAgListener -AvailabilityGroup $agName -Listener $listenerName -Port $port
             $module.Result.changed = $true
         }


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

## Description
Make sure we're comparing a property that is actually returned from the listener getter

## How Has This Been Tested?
We don't have AG tests due to the complexity at this time.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) - Fixes #206
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/CONTRIBUTING.md) document.
- [x] I have read/followed the [PR Quick Start Guide](https://docs.ansible.com/ansible/devel/community/create_pr_quick_start.html)
- [x] I have added tests to cover my changes or they are N/A.
- [ ] I have added a [changelog fragment](https://github.com/ansible-community/antsibull-changelog/blob/main/docs/changelogs.rst#changelog-fragment-categories) describing the changes.
- [ ] New module options/parameters include a [`version_added` property](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fields).
