### PR TITLE
Issue-214: Add ActiveStartDate to compare property

### DIFF
--- a/changelogs/fragments/214-fix-schedule-activestartdate.yml
+++ b/changelogs/fragments/214-fix-schedule-activestartdate.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Add ActiveStartDate to the compare properties so this item is marked accurately as changed.

--- a/plugins/modules/agent_job_schedule.ps1
+++ b/plugins/modules/agent_job_schedule.ps1
@@ -113,7 +113,7 @@ try {
                 $compareProperty = @(
                     "ActiveEndDate"
                     "ActiveEndTimeOfDay"
-                    "ActiveEndTimeOfDay"
+                    "ActiveStartDate"
                     "ActiveStartTimeOfDay"
                     "Description"
                     "FrequencyInterval"


### PR DESCRIPTION
Add ActiveStartDate to the compare properties so this item is marked accurately as changed.
