### PR TITLE
feat: add compatibility for dbops v0.9

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,19 @@ lowlydba.sqlserver Release Notes
 .. contents:: Topics
 
 
+v2.3.1
+======
+
+Release Summary
+---------------
+
+Update the install script feature to accommodate the latest minor DbOps release (v0.9.x)
+
+Minor Changes
+-------------
+
+- Add new input strings to be compatible with dbops v0.9.x (https://github.com/lowlydba/lowlydba.sqlserver/pull/231)
+
 v2.3.0
 ======
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lowlydba.sqlserver Collection for Ansible
+# lowlydba.sqlserver Collection for Ansible<!-- omit in toc -->
 
 ![GPL v3](https://img.shields.io/github/license/lowlydba/lowlydba.sqlserver)
 [![CI](https://github.com/lowlydba/lowlydba.sqlserver/actions/workflows/ansible-test.yml/badge.svg)](https://github.com/lowlydba/lowlydba.sqlserver/actions/workflows/ansible-test.yml)
@@ -11,11 +11,17 @@
 - [Contributing to this collection](#contributing-to-this-collection)
 - [Collection maintenance](#collection-maintenance)
 - [Tested with](#tested-with)
+  - [Ansible](#ansible)
+  - [SQL Server](#sql-server)
 - [External requirements](#external-requirements)
 - [Using this collection](#using-this-collection)
   - [Installing the Collection from Ansible Galaxy](#installing-the-collection-from-ansible-galaxy)
-- [Release notes](#release-notes)
 - [Releasing](#releasing)
+  - [Release notes](#release-notes)
+  - [Next Release](#next-release)
+  - [Schedule](#schedule)
+  - [Versioning](#versioning)
+  - [Deprecation](#deprecation)
 
 ## Modules
 
@@ -73,7 +79,7 @@ To learn how to maintain / become a maintainer of this collection, refer to the 
 
 - PowerShell modules
   - [dbatools][dbatools] >= 2.0.0
-  - [dbops][dbops] >= 0.8.0
+  - [dbops][dbops] >= 0.9.0
 
 ## Using this collection
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -473,3 +473,13 @@ releases:
     - 2-2-4-release-summary.yml
     - 227-skip-pwd-reset.yml
     release_date: '2024-02-10'
+  2.3.1:
+    changes:
+      minor_changes:
+      - Add new input strings to be compatible with dbops v0.9.x (https://github.com/lowlydba/lowlydba.sqlserver/pull/231)
+      release_summary: Update the install script feature to accommodate the latest
+        minor DbOps release (v0.9.x)
+    fragments:
+    - 2-3-1-release-summary.yml
+    - 231-dbops-v09.yml
+    release_date: '2024-02-24'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: lowlydba
 name: sqlserver
-version: 2.3.0
+version: 2.3.1
 readme: README.md
 authors:
   - John McCall (github.com/lowlydba)

--- a/plugins/modules/install_script.ps1
+++ b/plugins/modules/install_script.ps1
@@ -7,7 +7,7 @@
 #AnsibleRequires -CSharpUtil Ansible.Basic
 #AnsibleRequires -PowerShell ansible_collections.lowlydba.sqlserver.plugins.module_utils._SqlServerUtils
 #Requires -Modules @{ ModuleName="dbatools"; ModuleVersion="2.0.0" }
-#Requires -Modules @{ ModuleName="dbops"; ModuleVersion="0.8.0" }
+#Requires -Modules @{ ModuleName="dbops"; ModuleVersion="0.9.0" }
 
 $spec = @{
     supports_check_mode = $true
@@ -15,7 +15,7 @@ $spec = @{
         database = @{type = 'str'; required = $true }
         path = @{type = 'str'; required = $true }
         deployment_method = @{type = 'str'; required = $false; default = 'NoTransaction'
-            choices = @('NoTransaction', 'SingleTransaction', 'TransactionPerScript')
+            choices = @('NoTransaction', 'SingleTransaction', 'TransactionPerScript', 'AlwaysRollback')
         }
         schema_version_table = @{type = 'str'; required = $false }
         no_log_version = @{type = 'bool'; required = $false; default = $false }

--- a/plugins/modules/install_script.py
+++ b/plugins/modules/install_script.py
@@ -33,6 +33,7 @@ options:
       - C(SingleTransaction) - wrap all the deployment scripts into a single transaction and rollback whole deployment on error.
       - C(TransactionPerScript) - wrap each script into a separate transaction; rollback single script deployment in case of error.
       - C(NoTransaction) - deploy as is.
+      - C(AlwaysRollback) - roll back the transaction.
     type: str
     required: false
     default: 'NoTransaction'

--- a/plugins/modules/install_script.py
+++ b/plugins/modules/install_script.py
@@ -37,7 +37,7 @@ options:
     type: str
     required: false
     default: 'NoTransaction'
-    choices: ['NoTransaction', 'SingleTransaction', 'TransactionPerScript']
+    choices: ['NoTransaction', 'SingleTransaction', 'TransactionPerScript', 'AlwaysRollback']
   no_log_version:
     description:
       - If set, the deployment will not be tracked in the database. That will also mean that all the scripts

--- a/tests/integration/targets/setup_sqlserver/vars/main.yml
+++ b/tests/integration/targets/setup_sqlserver/vars/main.yml
@@ -6,7 +6,7 @@ dbatools_install_cmd: >
       Set-DbatoolsInsecureConnection -Scope FileUserLocal
   }
 
-dbops_min_version: 0.8.0
+dbops_min_version: 0.9.0
 dbops_install_cmd: >
   if (-not(Get-Module -FullyQualifiedName @{ModuleName='dbops';ModuleVersion='{{ dbops_min_version }}'} -ListAvailable)) {
       Install-Module dbops -MinimumVersion {{ dbops_min_version }} -Force -SkipPublisherCheck -AllowClobber


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

## Description
Add new input value to make compatible with dbops v0.9

## How Has This Been Tested?
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) - Fixes #
-  [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/CONTRIBUTING.md) document.
- [x] I have read/followed the [PR Quick Start Guide](https://docs.ansible.com/ansible/devel/community/create_pr_quick_start.html)
- [x] I have added tests to cover my changes or they are N/A.
- [x] I have added a [changelog fragment](https://github.com/ansible-community/antsibull-changelog/blob/main/docs/changelogs.rst#changelog-fragment-categories) describing the changes.
- [x] New module options/parameters include a [`version_added` property](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fields).
