### PR TITLE
changing ip_address param to expect list

### DIFF
--- a/changelogs/fragments/245-ag_listener-ip_address-fix.yml
+++ b/changelogs/fragments/245-ag_listener-ip_address-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - fixed the expected type of the ip_address parameter to be a list instead of a string (lowlydba.sqlserver.ag_listener)

--- a/changelogs/fragments/245-ag_listener-ip_address-fix.yml
+++ b/changelogs/fragments/245-ag_listener-ip_address-fix.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - fixed the expected type of the ip_address parameter to be a list instead of a string (lowlydba.sqlserver.ag_listener)
+  - fixed the expected type of the ip_address, subnet_ip, and subnet_mask parameters to be lists instead of strings (lowlydba.sqlserver.ag_listener)

--- a/plugins/modules/ag_listener.ps1
+++ b/plugins/modules/ag_listener.ps1
@@ -15,9 +15,9 @@ $spec = @{
     options = @{
         ag_name = @{type = 'str'; required = $true }
         listener_name = @{type = 'str'; required = $true }
-        ip_address = @{type = 'list'; required = $false }
-        subnet_ip = @{type = 'str'; required = $false }
-        subnet_mask = @{type = 'str'; required = $false; default = '255.255.255.0' }
+        ip_address = @{type = 'list'; elements= 'str'; required = $false }
+        subnet_ip = @{type = 'list'; elements= 'str'; required = $false }
+        subnet_mask = @{type = 'list'; elements= 'str'; required = $false; default = '255.255.255.0' }
         port = @{type = 'int'; required = $false; default = 1433 }
         dhcp = @{type = 'bool'; required = $false; default = $false }
         state = @{type = "str"; required = $false; default = "present"; choices = @("present", "absent") }

--- a/plugins/modules/ag_listener.ps1
+++ b/plugins/modules/ag_listener.ps1
@@ -15,9 +15,9 @@ $spec = @{
     options = @{
         ag_name = @{type = 'str'; required = $true }
         listener_name = @{type = 'str'; required = $true }
-        ip_address = @{type = 'list'; elements= 'str'; required = $false }
-        subnet_ip = @{type = 'list'; elements= 'str'; required = $false }
-        subnet_mask = @{type = 'list'; elements= 'str'; required = $false; default = '255.255.255.0' }
+        ip_address = @{type = 'list'; elements = 'str'; required = $false }
+        subnet_ip = @{type = 'list'; elements = 'str'; required = $false }
+        subnet_mask = @{type = 'list'; elements = 'str'; required = $false; default = '255.255.255.0' }
         port = @{type = 'int'; required = $false; default = 1433 }
         dhcp = @{type = 'bool'; required = $false; default = $false }
         state = @{type = "str"; required = $false; default = "present"; choices = @("present", "absent") }

--- a/plugins/modules/ag_listener.ps1
+++ b/plugins/modules/ag_listener.ps1
@@ -15,7 +15,7 @@ $spec = @{
     options = @{
         ag_name = @{type = 'str'; required = $true }
         listener_name = @{type = 'str'; required = $true }
-        ip_address = @{type = 'str'; required = $false }
+        ip_address = @{type = 'list'; required = $false }
         subnet_ip = @{type = 'str'; required = $false }
         subnet_mask = @{type = 'str'; required = $false; default = '255.255.255.0' }
         port = @{type = 'int'; required = $false; default = 1433 }

--- a/plugins/modules/ag_listener.py
+++ b/plugins/modules/ag_listener.py
@@ -74,9 +74,13 @@ EXAMPLES = r'''
     sql_instance_primary: sql-01.myco.io
     ag_name: AG_MyDatabase
     listener_name: aglMyDatabase
-    ip_address: 10.0.20.20,10.1.77.77
-    subnet_ip: 255.255.252.0
-    subnet_mask: 255.255.255.0
+    ip_address:
+      - 10.0.20.20
+      - 10.1.77.77
+    subnet_ip:
+      - 255.255.252.0
+    subnet_mask:
+      - 255.255.255.0
 '''
 
 RETURN = r'''

--- a/plugins/modules/ag_listener.py
+++ b/plugins/modules/ag_listener.py
@@ -25,17 +25,20 @@ options:
   ip_address:
     description:
       - IP address(es) of the listener. Comma separated if multiple.
-    type: str
+    type: list
+    elements: str
     required: false
   subnet_ip:
     description:
       - Subnet IP address(es) of the listener. Comma separated if multiple.
-    type: str
+    type: list
+    elements: str
     required: false
   subnet_mask:
     description:
       - Sets the subnet IP mask(s) of the availability group listener. Comma separated if multiple.
-    type: str
+    type: list
+    elements: str
     required: false
     default: 255.255.255.0
   port:

--- a/plugins/modules/spn.py
+++ b/plugins/modules/spn.py
@@ -52,9 +52,13 @@ EXAMPLES = r'''
     sql_instance_primary: sql-01.myco.io
     ag_name: AG_MyDatabase
     listener_name: aglMyDatabase
-    ip_address: 10.0.20.20,10.1.77.77
-    subnet_ip: 255.255.252.0
-    subnet_mask: 255.255.255.0
+    ip_address:
+      - 10.0.20.20
+      - 10.1.77.77
+    subnet_ip:
+      - 255.255.252.0
+    subnet_mask:
+      - 255.255.255.0
 
 - name: Add SPN for new AG listener on port 1433
   lowlydba.sqlserver.spn:

--- a/tests/integration/targets/win_ag_listener/tasks/main.yml
+++ b/tests/integration/targets/win_ag_listener/tasks/main.yml
@@ -25,8 +25,10 @@
       ag_name: "{{ ag_name }}"
       listener_name: "{{ listener_name }}"
       port: "{{ port }}"
-      ip_address: "192.168.6.9"
-      subnet_mask: "255.255.255.0"
+      ip_address:
+        - "192.168.6.9"
+      subnet_mask:
+        - "255.255.255.0"
   tags: ["ag_listener"]
   block:
     - name: Enable hadr


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

## Description
changing spec options, ip_address parameter is being changed from a 'str' type to a 'list' type

<!--- Why is this change required? What problem does it solve? -->

fixes issue #245

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

validated the change using a local collection of lowlydba and was able to successfully create a multi subnet ag listener when the ip_address parameter was expecting a list

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue) - Fixes #
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/CONTRIBUTING.md) document.
- [x ] I have read/followed the [PR Quick Start Guide](https://docs.ansible.com/ansible/devel/community/create_pr_quick_start.html)
- [x ] I have added tests to cover my changes or they are N/A.
- [x ] I have added a [changelog fragment](https://github.com/ansible-community/antsibull-changelog/blob/main/docs/changelogs.rst#changelog-fragment-categories) describing the changes.
- [ ] New module options/parameters include a [`version_added` property](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fields).
