### PR TITLE
chore: use newer python for dlevel

### DIFF
--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -143,8 +143,8 @@ jobs:
 
       - name: Install ansible-base (${{ matrix.ansible }})
         run: |
-          ${{ matrix.python }} -m pip install --upgrade pip setuptools pypsrp --disable-pip-version-check --retries 10
-          ${{ matrix.python }} -m pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check --retries 10
+          sudo ${{ matrix.python }} -m pip install --upgrade pip setuptools pypsrp --disable-pip-version-check --retries 10
+          sudo ${{ matrix.python }} -m pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check --retries 10
 
       - name: Install collection dependencies
         id: collection-dependency

--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -107,7 +107,7 @@ jobs:
 
       - uses: Vampire/setup-wsl@v3.1.1
         with:
-          distribution: Ubuntu-22.04
+          distribution: Ubuntu-24.04
           update: "true"
           use-cache: "true"
           additional-packages: |

--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -54,7 +54,7 @@ jobs:
           - devel
         python:
           - python3
-          - python3.10
+          - python3.11
         group: # windows/group/#/
           - "1"
           - "2"

--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -141,13 +141,16 @@ jobs:
           $ws = ConvertTo-LinuxPathCrappy -LiteralPath "${{ github.workspace }}"
           Add-Content -LiteralPath $env:GITHUB_ENV -Value "GHWS=$ws"
 
-      - name: Allow system breaking pip installs
-        run: python3 -m pip config set global.break-system-packages true
 
+      - name: Allow system breaking pip installs
+        run:
+
+      # Override break-sys-pkg defaults, because we don't need to bother with python venv for CI
       - name: Install ansible-base (${{ matrix.ansible }})
         run: |
-          ${{ matrix.python }} -m pip install --upgrade setuptools pypsrp --disable-pip-version-check --retries 10 --break-system-packages
-          ${{ matrix.python }} -m pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check --retries 10 --break-system-packages
+          ${{ matrix.python }} -m pip config set global.break-system-packages true
+          ${{ matrix.python }} -m pip install --upgrade setuptools pypsrp --disable-pip-version-check --retries 10
+          ${{ matrix.python }} -m pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check --retries 10
 
       - name: Install collection dependencies
         id: collection-dependency

--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -131,9 +131,6 @@ jobs:
           $ws = ConvertTo-LinuxPathCrappy -LiteralPath "${{ github.workspace }}"
           Add-Content -LiteralPath $env:GITHUB_ENV -Value "GHWS=$ws"
 
-      - name: Allow system breaking pip installs
-        run:
-
       # Override break-sys-pkg defaults, because we don't need to bother with python venv for CI
       - name: Install ansible-base (${{ matrix.ansible }})
         run: |

--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -143,8 +143,8 @@ jobs:
 
       - name: Install ansible-base (${{ matrix.ansible }})
         run: |
-          sudo ${{ matrix.python }} -m pip install --upgrade pip setuptools pypsrp --disable-pip-version-check --retries 10
-          sudo ${{ matrix.python }} -m pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check --retries 10
+          ${{ matrix.python }} -m pip install --upgrade setuptools pypsrp --disable-pip-version-check --retries 10 --break-system-packages
+          ${{ matrix.python }} -m pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check --retries 10 --break-system-packages
 
       - name: Install collection dependencies
         id: collection-dependency

--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -183,11 +183,15 @@ jobs:
         run: |
           pushd "${{ env.GHWS }}/ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}"
           ansible-test windows-integration -v --color --retry-on-error --continue-on-error --diff --coverage --requirements windows/group/${{ matrix.group }}/
+        env:
+          PIP_BREAK_SYSTEM_PACKAGES: 1
 
       - name: Generate coverage report
         run: |
           pushd "${{ env.GHWS }}/ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}"
           ansible-test coverage xml -v --requirements
+        env:
+          PIP_BREAK_SYSTEM_PACKAGES: 1
 
       # See the reports at https://codecov.io/gh/lowlydba/lowlydba.sqlserver
       - uses: codecov/codecov-action@v4.5.0

--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -141,6 +141,9 @@ jobs:
           $ws = ConvertTo-LinuxPathCrappy -LiteralPath "${{ github.workspace }}"
           Add-Content -LiteralPath $env:GITHUB_ENV -Value "GHWS=$ws"
 
+      - name: Allow system breaking pip installs
+        run: python3 -m pip config set global.break-system-packages true
+
       - name: Install ansible-base (${{ matrix.ansible }})
         run: |
           ${{ matrix.python }} -m pip install --upgrade setuptools pypsrp --disable-pip-version-check --retries 10 --break-system-packages

--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -54,18 +54,19 @@ jobs:
           - devel
         python:
           - python3
-          - python3.11
+          - python3.12
         group: # windows/group/#/
           - "1"
           - "2"
-          #- '3'
         exclude:
           - ansible: stable-2.13
-            python: python3.11
+            python: python3.12
           - ansible: stable-2.14
-            python: python3.11
+            python: python3.12
           - ansible: stable-2.15
-            python: python3.11
+            python: python3.12
+          - ansible: stable-2.16
+            python: python3.12
           - ansible: devel
             python: python3
     defaults:

--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -141,7 +141,6 @@ jobs:
           $ws = ConvertTo-LinuxPathCrappy -LiteralPath "${{ github.workspace }}"
           Add-Content -LiteralPath $env:GITHUB_ENV -Value "GHWS=$ws"
 
-
       - name: Allow system breaking pip installs
         run:
 

--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -61,11 +61,11 @@ jobs:
           #- '3'
         exclude:
           - ansible: stable-2.13
-            python: python3.10
+            python: python3.11
           - ansible: stable-2.14
-            python: python3.10
+            python: python3.11
           - ansible: stable-2.15
-            python: python3.10
+            python: python3.11
           - ansible: devel
             python: python3
     defaults:

--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -107,7 +107,7 @@ jobs:
       - uses: Vampire/setup-wsl@v3.1.1
         with:
           distribution: ${{ matrix.wsl }}
-          update: "true"
+          update: "false"
           use-cache: "true"
           additional-packages: |
             git

--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -46,29 +46,28 @@ jobs:
       matrix:
         os:
           - windows-2022
+        wsl:
+          - Ubuntu-24.04
         ansible:
-          - stable-2.13
-          - stable-2.14
-          - stable-2.15
           - stable-2.16
+          - stable-2.17
           - devel
         python:
           - python3
-          - python3.12
+          #- python3.10
         group: # windows/group/#/
           - "1"
           - "2"
-        exclude:
-          - ansible: stable-2.13
-            python: python3.12
-          - ansible: stable-2.14
-            python: python3.12
-          - ansible: stable-2.15
-            python: python3.12
-          - ansible: stable-2.16
-            python: python3.12
-          - ansible: devel
-            python: python3
+          #- '3'
+        # exclude:
+        #   - ansible: stable-2.13
+        #     python: python3.10
+        #   - ansible: stable-2.14
+        #     python: python3.10
+        #   - ansible: stable-2.15
+        #     python: python3.10
+        #   - ansible: devel
+        #     python: python3
     defaults:
       run:
         shell: wsl-bash {0}
@@ -107,7 +106,7 @@ jobs:
 
       - uses: Vampire/setup-wsl@v3.1.1
         with:
-          distribution: Ubuntu-22.04
+          distribution: ${{ matrix.wsl }}
           update: "true"
           use-cache: "true"
           additional-packages: |

--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -54,20 +54,10 @@ jobs:
           - devel
         python:
           - python3
-          #- python3.10
         group: # windows/group/#/
           - "1"
           - "2"
           #- '3'
-        # exclude:
-        #   - ansible: stable-2.13
-        #     python: python3.10
-        #   - ansible: stable-2.14
-        #     python: python3.10
-        #   - ansible: stable-2.15
-        #     python: python3.10
-        #   - ansible: devel
-        #     python: python3
     defaults:
       run:
         shell: wsl-bash {0}

--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -183,15 +183,11 @@ jobs:
         run: |
           pushd "${{ env.GHWS }}/ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}"
           ansible-test windows-integration -v --color --retry-on-error --continue-on-error --diff --coverage --requirements windows/group/${{ matrix.group }}/
-        env:
-          PIP_BREAK_SYSTEM_PACKAGES: 1
 
       - name: Generate coverage report
         run: |
           pushd "${{ env.GHWS }}/ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}"
           ansible-test coverage xml -v --requirements
-        env:
-          PIP_BREAK_SYSTEM_PACKAGES: 1
 
       # See the reports at https://codecov.io/gh/lowlydba/lowlydba.sqlserver
       - uses: codecov/codecov-action@v4.5.0

--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -107,7 +107,7 @@ jobs:
 
       - uses: Vampire/setup-wsl@v3.1.1
         with:
-          distribution: Ubuntu-24.04
+          distribution: Ubuntu-22.04
           update: "true"
           use-cache: "true"
           additional-packages: |


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

Fix broken dlevel tests. This ended up being a bit more involved than expected:

* Upgrade wsl to use Ubuntu 24
* Remove auto-update of Ubuntu packages, updating `systemd` in (WSL1, Ubuntu 24) errors out 
* Remove ansible core versions that are no longer in support
* Add ansible core versions that are in support

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) - Fixes #
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/CONTRIBUTING.md) document.
- [x] I have read/followed the [PR Quick Start Guide](https://docs.ansible.com/ansible/devel/community/create_pr_quick_start.html)
- [x] I have added tests to cover my changes or they are N/A.
- [x] I have added a [changelog fragment](https://github.com/ansible-community/antsibull-changelog/blob/main/docs/changelogs.rst#changelog-fragment-categories) describing the changes.
- [x] New module options/parameters include a [`version_added` property](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fields).
