### PR TITLE
fix: Include warnings for restore failures

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ lowlydba.sqlserver Release Notes
 
 .. contents:: Topics
 
+v2.3.4
+======
+
+Bugfixes
+--------
+
+- Include warning logs in failure output for the restore module to indicate root causes (https://github.com/lowlydba/lowlydba.sqlserver/pull/266).
+
 v2.3.3
 ======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ lowlydba.sqlserver Release Notes
 v2.3.4
 ======
 
+Release Summary
+---------------
+
+Minor bugfix for failed database restores.
+
 Bugfixes
 --------
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -505,3 +505,12 @@ releases:
     - 2-3-3-release-summary.yml
     - 245-ag_listener-ip_address-fix.yml
     release_date: '2024-06-06'
+  2.3.4:
+    changes:
+      bugfixes:
+      - Include warning logs in failure output for the restore module to indicate
+        root causes (https://github.com/lowlydba/lowlydba.sqlserver/pull/266).
+      release_summary: Minor bugfix for failed database restores.
+    fragments:
+    - 266-restore-warnings.yaml
+    release_date: '2024-10-06'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: lowlydba
 name: sqlserver
-version: 2.3.3
+version: 2.3.4
 readme: README.md
 authors:
   - John McCall (github.com/lowlydba)

--- a/plugins/modules/restore.ps1
+++ b/plugins/modules/restore.ps1
@@ -167,9 +167,9 @@ try {
 }
 catch {
     # Restore command hides relevant error info as warnings, so append warning logs to any failures
-    $warningMessage = "";
+    $warningMessage = ""
     if ($warnings) {
-        $warningMessage = "Additional warnings: $warnings."
+        $warningMessage = " Additional warnings: $warnings."
     }
-    $module.FailJson("Error restoring database: $($_.Exception.Message). $warningMessage", $_)
+    $module.FailJson("Error restoring database: $($_.Exception.Message).$warningMessage", $_)
 }

--- a/plugins/modules/restore.ps1
+++ b/plugins/modules/restore.ps1
@@ -156,7 +156,7 @@ try {
     if ($null -ne $keepCDC) {
         $restoreSplat.Add("KeepCDC", $keepCDC)
     }
-    $output = Restore-DbaDatabase @restoreSplat
+    $output = Restore-DbaDatabase @restoreSplat -WarningVariable warnings
 
     if ($null -ne $output) {
         $resultData = ConvertTo-SerializableObject -InputObject $output
@@ -166,5 +166,10 @@ try {
     $module.ExitJson()
 }
 catch {
-    $module.FailJson("Error restoring database: $($_.Exception.Message).", $_)
+    # Restore command hides relevant error info as warnings, so append warning logs to any failures
+    $warningMessage = "";
+    if ($warnings) {
+        $warningMessage = "Additional warnings: $warnings."
+    }
+    $module.FailJson("Error restoring database: $($_.Exception.Message). $warningMessage", $_)
 }

--- a/tests/integration/targets/win_restore/tasks/main.yml
+++ b/tests/integration/targets/win_restore/tasks/main.yml
@@ -48,4 +48,4 @@
         that:
           - error_result.failed == true
           - "'already exists' in error_result.msg"
-          - error_result.msg is not None
+          - error_result.msg != None

--- a/tests/integration/targets/win_restore/tasks/main.yml
+++ b/tests/integration/targets/win_restore/tasks/main.yml
@@ -29,3 +29,23 @@
         that:
           - result.data.SqlInstance != None
           - result.data.Database == restore_database
+
+    - name: Test error when restoring to an existing database
+      lowlydba.sqlserver.restore:
+        sql_instance: "{{ sqlserver_instance }}"
+        sql_username: "{{ sqlserver_username }}"
+        sql_password: "{{ sqlserver_password }}"
+        database: "{{ restore_database }}"
+        path: "{{ backup_result.data.BackupPath }}"
+        replace_db_name_in_file: true
+        block_size: "16kb"
+        destination_file_suffix: "_new"
+        destination_file_prefix: "db_"
+      register: error_result
+      failed_when: error_result.failed
+      ignore_errors: true
+    - assert:
+        that:
+          - error_result.failed == true
+          - "'already exists' in error_result.msg"
+          - error_result.msg is not None


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

## Description
There is some contextual info that is relevant for debugging database restores that only appears as warning logs in dbatools, thereby not making it natively accessible to Ansible. 

Append the warnings for the restore command to the failure json to increase usability.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) - Fixes #263
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/CONTRIBUTING.md) document.
- [x] I have read/followed the [PR Quick Start Guide](https://docs.ansible.com/ansible/devel/community/create_pr_quick_start.html)
- [x] I have added tests to cover my changes or they are N/A.
- [x] I have added a [changelog fragment](https://github.com/ansible-community/antsibull-changelog/blob/main/docs/changelogs.rst#changelog-fragment-categories) describing the changes.
- [x] New module options/parameters include a [`version_added` property](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fields).
