### PR TITLE
fix: changed login status to be more accurate

### DIFF
--- a/plugins/modules/login.ps1
+++ b/plugins/modules/login.ps1
@@ -100,7 +100,6 @@ try {
         }
         if (($null -ne $secPassword) -and ($skip_password_reset -eq $false)) {
             $setLoginSplat.add("SecurePassword", $secPassword)
-            $changed = $true
         }
 
         # Login already exists
@@ -114,10 +113,15 @@ try {
                 $disabled = $false
                 $setLoginSplat.add("Enable", $true)
             }
-            # Login needs to be modified
-            if (($changed -eq $true) -or ($disabled -ne $existingLogin.IsDisabled) -or ($setLoginSplat.ContainsKey("SecurePassword"))) {
+            if ($disabled -ne $existingLogin.IsDisabled) {
+                $changed = $true
+            }
+            # Login needs to be modified (or password *may* be changed)
+            if (($changed -eq $true) -or ($setLoginSplat.ContainsKey("SecurePassword"))) {
                 $output = Set-DbaLogin @setLoginSplat
-                $module.result.changed = $true
+                if (($output.PasswordChanged) -eq $true -or ($changed -eq $true)) {
+                    $module.result.changed = $true
+                }
             }
         }
         # New login

--- a/tests/integration/targets/login/tasks/main.yml
+++ b/tests/integration/targets/login/tasks/main.yml
@@ -37,6 +37,7 @@
     - name: Modify login
       lowlydba.sqlserver.login:
         default_database: "model"
+        password: "new_password"
         enabled: true
       register: result
     - assert:
@@ -45,6 +46,21 @@
           - result.data.ComputerName != None
           - result.data.InstanceName != None
           - result.data.SqlInstance != None
+          - result.data.IsDisabled is false
+          - result.data.Name == "{{ login_name }}"
+          - result.data.DefaultDatabase == "model"
+          - result.data.PasswordChanged is true
+
+    - name: Don't modify login
+      lowlydba.sqlserver.login:
+        default_database: "model"
+        password: "new_password"
+        enabled: true
+      register: result
+    - assert:
+        that:
+          - result is not changed
+          - result.data.PasswordChanged is false
           - result.data.IsDisabled is false
           - result.data.Name == "{{ login_name }}"
           - result.data.DefaultDatabase == "model"


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

## Description
When a password is included for a login, only set the result `changed` to true if the password *actually* changed. dbatools provides the `PasswordChanged` boolean upstream that can be used to determine this after the login has been adjusted.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) - Fixes #256 
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/CONTRIBUTING.md) document.
- [x] I have read/followed the [PR Quick Start Guide](https://docs.ansible.com/ansible/devel/community/create_pr_quick_start.html)
- [x] I have added tests to cover my changes or they are N/A.
- [x] I have added a [changelog fragment](https://github.com/ansible-community/antsibull-changelog/blob/main/docs/changelogs.rst#changelog-fragment-categories) describing the changes.
- [x] New module options/parameters include a [`version_added` property](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fields).
