### PR TITLE
chore: remove EOL versions

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -52,10 +52,8 @@ jobs:
         ansible:
           # It's important that Sanity is tested against all stable-X.Y branches
           # Testing against `devel` may fail as new tests are added.
-          - stable-2.13
-          - stable-2.14
-          - stable-2.15
           - stable-2.16
+          - stable-2.17
           - devel
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -65,9 +65,8 @@ To learn how to maintain / become a maintainer of this collection, refer to the 
 
 ### Ansible
 
-- 2.13
-- 2.14
-- 2.15
+- 2.16
+- 2.17
 - dlevel
 
 ### SQL Server


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Remove testing for EOL ansible versions
