### PR TITLE
fix: create login properly when skip reset set

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,19 @@ lowlydba.sqlserver Release Notes
 
 .. contents:: Topics
 
+v2.3.5
+======
+
+Release Summary
+---------------
+
+Bugfix for login module when creating new logins.
+
+Bugfixes
+--------
+
+- Fix error that occurred when creating a login with `skip_password_reset` as true. (https://github.com/lowlydba/lowlydba.sqlserver/pull/287)
+
 v2.3.4
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -514,3 +514,12 @@ releases:
     fragments:
     - 266-restore-warnings.yaml
     release_date: '2024-10-06'
+  2.3.5:
+    changes:
+      bugfixes:
+      - Fix error that occurred when creating a login with `skip_password_reset` as
+        true. (https://github.com/lowlydba/lowlydba.sqlserver/pull/287)
+      release_summary: Bugfix for login module when creating new logins.
+    fragments:
+    - 287-login-bugfix.yml
+    release_date: '2024-12-08'

--- a/plugins/modules/login.ps1
+++ b/plugins/modules/login.ps1
@@ -98,13 +98,14 @@ try {
                 $setLoginSplat.add("PasswordMustChange", $true)
             }
         }
-        if (($null -ne $secPassword) -and ($skip_password_reset -eq $false)) {
-            $setLoginSplat.add("SecurePassword", $secPassword)
-            $changed = $true
-        }
 
         # Login already exists
         if ($null -ne $existingLogin) {
+            if (($null -ne $secPassword) -and ($skip_password_reset -eq $false)) {
+                $setLoginSplat.add("SecurePassword", $secPassword)
+                $changed = $true
+            }
+
             # Splat login status
             if ($enabled -eq $false) {
                 $disabled = $true

--- a/plugins/modules/login.ps1
+++ b/plugins/modules/login.ps1
@@ -123,6 +123,7 @@ try {
         }
         # New login
         else {
+            $setLoginSplat.add("SecurePassword", $secPassword)
             if ($null -ne $language) {
                 $setLoginSplat.add("Language", $language)
             }
@@ -140,7 +141,6 @@ try {
             $output.PSStandardMembers.DefaultDisplayPropertySet.ReferencedPropertyNames.Add("DefaultDatabase")
             $output.PSStandardMembers.DefaultDisplayPropertySet.ReferencedPropertyNames.Add("Language")
         }
-
     }
 
     if ($null -ne $output) {

--- a/tests/integration/targets/login/tasks/main.yml
+++ b/tests/integration/targets/login/tasks/main.yml
@@ -29,6 +29,7 @@
     - name: Create login
       lowlydba.sqlserver.login:
         password_policy_enforced: "{{ password_policy_enforced }}"
+        skip_password_reset: true
       register: result
     - assert:
         that:


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

## Description
When creating a login, the login should still be created even if `skip_password_reset` is true.

## How Has This Been Tested?
Incorporated into test 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) - Fixes #282 
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/CONTRIBUTING.md) document.
- [x] I have read/followed the [PR Quick Start Guide](https://docs.ansible.com/ansible/devel/community/create_pr_quick_start.html)
- [x] I have added tests to cover my changes or they are N/A.
- [x] I have added a [changelog fragment](https://github.com/ansible-community/antsibull-changelog/blob/main/docs/changelogs.rst#changelog-fragment-categories) describing the changes.
- [x] New module options/parameters include a [`version_added` property](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fields).
