### PR TITLE
fix: dont error with enable on create

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,19 @@ lowlydba.sqlserver Release Notes
 
 .. contents:: Topics
 
+v2.3.6
+======
+
+Release Summary
+---------------
+
+Bugfix for creating agent job schedules as explicitly enabled.
+
+Bugfixes
+--------
+
+- Fix error when creating an agent job schedule with `enabled` as true. (https://github.com/lowlydba/lowlydba.sqlserver/pull/288)
+
 v2.3.5
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -523,3 +523,11 @@ releases:
     fragments:
     - 287-login-bugfix.yml
     release_date: '2024-12-08'
+  2.3.6:
+    changes:
+      bugfixes:
+      - Fix error when creating an agent job schedule with `enabled` as true. (https://github.com/lowlydba/lowlydba.sqlserver/pull/288)
+      release_summary: Bugfix for creating agent job schedules as explicitly enabled.
+    fragments:
+    - 288-fix-agent-schedule.yml
+    release_date: '2024-12-08'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: lowlydba
 name: sqlserver
-version: 2.3.4
+version: 2.3.6
 readme: README.md
 authors:
   - John McCall (github.com/lowlydba)

--- a/plugins/doc_fragments/288-fix-agent-schedule.yml
+++ b/plugins/doc_fragments/288-fix-agent-schedule.yml
@@ -1,3 +1,0 @@
-bugfixes:
-  - Fix error when creating an agent job schedule with `enabled` as true. (https://github.com/lowlydba/lowlydba.sqlserver/pull/288)
-release_summary: Bugfix for creating agent job schedules as explicitly enabled.

--- a/plugins/doc_fragments/288-fix-agent-schedule.yml
+++ b/plugins/doc_fragments/288-fix-agent-schedule.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Fix error when creating an agent job schedule with `enabled` as true. (https://github.com/lowlydba/lowlydba.sqlserver/pull/288)
+release_summary: Bugfix for creating agent job schedules as explicitly enabled.

--- a/plugins/modules/agent_job_schedule.ps1
+++ b/plugins/modules/agent_job_schedule.ps1
@@ -101,11 +101,11 @@ if ($null -ne $frequencyRecurrenceFactor) {
 try {
     $existingSchedule = Get-DbaAgentSchedule -SqlInstance $SqlInstance -SqlCredential $sqlCredential -Schedule $schedule
     if ($state -eq "present") {
-        if ($enabled -eq $true) {
-            $scheduleParams.Add("Enabled", $true)
-        }
         # Update schedule
         if ($null -ne $existingSchedule) {
+            if ($enabled -eq $true) {
+                $scheduleParams.Add("Enabled", $true)
+            }
             # Need to serialize to prevent SMO auto refreshing
             $old = ConvertTo-SerializableObject -InputObject $existingSchedule -UseDefaultProperty $false
             $output = Set-DbaAgentSchedule @scheduleParams

--- a/tests/integration/targets/agent_job_schedule/tasks/main.yml
+++ b/tests/integration/targets/agent_job_schedule/tasks/main.yml
@@ -49,6 +49,7 @@
       lowlydba.sqlserver.agent_job_schedule:
         schedule: "{{ forced_schedule_name }}"
         force: true
+        enabled: true
         state: present
       register: result
     - assert:


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

## Description
Fix error when attempting to create a new job schedule with `enabled` as true.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) - Fixes #273 
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/CONTRIBUTING.md) document.
- [x] I have read/followed the [PR Quick Start Guide](https://docs.ansible.com/ansible/devel/community/create_pr_quick_start.html)
- [x] I have added tests to cover my changes or they are N/A.
- [ ] I have added a [changelog fragment](https://github.com/ansible-community/antsibull-changelog/blob/main/docs/changelogs.rst#changelog-fragment-categories) describing the changes.
- [x] New module options/parameters include a [`version_added` property](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fields).
