### PR TITLE
chore: add ansible 2.18 to test matrix

### DIFF
--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -49,8 +49,9 @@ jobs:
         wsl:
           - Ubuntu-24.04
         ansible:
-          - stable-2.16
-          - stable-2.17
+          - stable-2.16 # May 2025 EOL
+          - stable-2.17 # November 2025 EOL
+          - stable-2.18
           - devel
         python:
           - python3

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -108,6 +108,7 @@ jobs:
         ansible:
           - stable-2.16
           - stable-2.17
+          - stable-2.18
           - devel
         python:
           - 3.10

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -52,8 +52,9 @@ jobs:
         ansible:
           # It's important that Sanity is tested against all stable-X.Y branches
           # Testing against `devel` may fail as new tests are added.
-          - stable-2.16
-          - stable-2.17
+          - stable-2.16 # May 2025 EOL
+          - stable-2.17 # November 2025 EOL
+          - stable-2.18
           - devel
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ To learn how to maintain / become a maintainer of this collection, refer to the 
 
 - 2.16
 - 2.17
+- 2.18
 - dlevel
 
 ### SQL Server


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

## Description
Add version 2.18 explicitly to the test matrixes in GitHub.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) - Fixes #
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/CONTRIBUTING.md) document.
- [x] I have read/followed the [PR Quick Start Guide](https://docs.ansible.com/ansible/devel/community/create_pr_quick_start.html)
- [x] I have added tests to cover my changes or they are N/A.
- [ ] I have added a [changelog fragment](https://github.com/ansible-community/antsibull-changelog/blob/main/docs/changelogs.rst#changelog-fragment-categories) describing the changes.
- [x] New module options/parameters include a [`version_added` property](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fields).
