### PR TITLE
chore: bump vampire wsl GHA to v4

### DIFF
--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -95,11 +95,12 @@ jobs:
         shell: cmd
         run: echo 127.0.0.1 sqlserver >> "%WinDir%\System32\Drivers\etc\hosts"
 
-      - uses: Vampire/setup-wsl@v3.1.3
+      - uses: Vampire/setup-wsl@v4.1.0
         with:
           distribution: ${{ matrix.wsl }}
           update: "false"
           use-cache: "true"
+          wsl-version: 1
           additional-packages: |
             git
             ${{ matrix.python }}


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

## Description
Bump to the latest major version of the WSL action used to setup Windows test workflows.

At this time, using the newly enabled WSL2 is problematic (efforts to make it work: https://github.com/lowlydba/lowlydba.sqlserver/pull/284) so we will keep WSL1 to at least get the updated version in place.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) - Fixes #
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/CONTRIBUTING.md) document.
- [x] I have read/followed the [PR Quick Start Guide](https://docs.ansible.com/ansible/devel/community/create_pr_quick_start.html)
- [x] I have added tests to cover my changes or they are N/A.
- [ ] I have added a [changelog fragment](https://github.com/ansible-community/antsibull-changelog/blob/main/docs/changelogs.rst#changelog-fragment-categories) describing the changes.
- [x] New module options/parameters include a [`version_added` property](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fields).
