### PR TITLE
update githubaction runner version to 1.17 to fix python errors in sanity checks

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -68,7 +68,7 @@ jobs:
           path: ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
 
       - name: Run confidence tests
-        uses: ansible-community/ansible-test-gh-action@v1.16.0
+        uses: ansible-community/ansible-test-gh-action@v1.17.0
         with:
           ansible-core-version: ${{ matrix.ansible }}
           testing-type: sanity
@@ -129,7 +129,7 @@ jobs:
       # Prevent dbatools v2+ issues with newer docker image for 2.13
       - name: Run integration tests - v2.13 workaround
         if: ${{ matrix.ansible == 'stable-2.13' }}
-        uses: ansible-community/ansible-test-gh-action@v1.16.0
+        uses: ansible-community/ansible-test-gh-action@v1.17.0
         with:
           docker-image: 'quay.io/ansible/default-test-container:6.13.0'
           ansible-core-version: ${{ matrix.ansible }}
@@ -140,7 +140,7 @@ jobs:
 
       - name: Run integration tests
         if: ${{ matrix.ansible != 'stable-2.13'}}
-        uses: ansible-community/ansible-test-gh-action@v1.16.0
+        uses: ansible-community/ansible-test-gh-action@v1.17.0
         with:
           ansible-core-version: ${{ matrix.ansible }}
           #target-python-version: ${{ matrix.python }}


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Github action runner python version alignment used in sanity checks was out of date upstream. This updates the version to the recently released runner version.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Run through github actions, seems to fix it in my repo.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) - Fixes #
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/CONTRIBUTING.md) document.
- [X] I have read/followed the [PR Quick Start Guide](https://docs.ansible.com/ansible/devel/community/create_pr_quick_start.html)
- [X] I have added tests to cover my changes or they are N/A.
- [ ] I have added a [changelog fragment](https://github.com/ansible-community/antsibull-changelog/blob/main/docs/changelogs.rst#changelog-fragment-categories) describing the changes.
- [ ] New module options/parameters include a [`version_added` property](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fields).
