### PR TITLE
fix: remove use of deprecated ansible python types

### DIFF
--- a/changelogs/fragments/remove-six-usage.yml
+++ b/changelogs/fragments/remove-six-usage.yml
@@ -1,0 +1,2 @@
+trivial:
+  - Replace deprecated ``ansible.module_utils.six`` (``text_type``/``binary_type``) with native Python 3 ``str``/``bytes`` in test connection plugin ``local_pwsh`` (PR #334).


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Remove use of deprecated ansible python types to pass dlevel sanity tests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) - Fixes #
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/CONTRIBUTING.md) document.
- [x] I have read/followed the [PR Quick Start Guide](https://docs.ansible.com/ansible/devel/community/create_pr_quick_start.html)
- [x] I have added tests to cover my changes or they are N/A.
- [x] I have added a [changelog fragment](https://github.com/ansible-community/antsibull-changelog/blob/main/docs/changelogs.rst#changelog-fragment-categories) describing the changes.
- [ ] New module options/parameters include a [`version_added` property](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fields).
