### PR TITLE
Add Galaxy overwrite check and use gh for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
       version:
         description: "Version number to release"
         required: true
+      overwrite_existing:
+        description: "Overwrite version if already published to Galaxy"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: release-${{ github.ref }}
@@ -24,6 +29,7 @@ jobs:
       contents: write  # Required for creating releases and tags
     env:
       VERSION: ${{ github.event.inputs.version }}  # zizmor: ignore[template-injection] -- User input is required for this workflow
+      OVERWRITE_EXISTING: ${{ github.event.inputs.overwrite_existing }}  # zizmor: ignore[template-injection] -- Boolean input is safe for this comparison
       GHP_BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
       GALAXY_API_KEY: ${{ secrets.GALAXY_API_KEY }}  # zizmor: ignore[secrets-outside-env] -- Galaxy API key needed for publishing; workflow_dispatch only
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] -- GitHub token needed for release creation; workflow_dispatch only
@@ -40,6 +46,23 @@ jobs:
 
       - name: Install PyYaml
         run: pip install pyyaml
+
+      - name: Check if version exists on Galaxy
+        id: check_galaxy_version
+        run: |
+          if curl --head -s -f -o /dev/null "https://galaxy.ansible.com/download/lowlydba-sqlserver-${VERSION}.tar.gz"; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Version ${VERSION} already exists on Galaxy"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Version ${VERSION} does not yet exist on Galaxy"
+          fi
+
+      - name: Abort if version exists and overwrite not enabled
+        if: steps.check_galaxy_version.outputs.exists == 'true' && env.OVERWRITE_EXISTING != 'true'
+        run: |
+          echo "::error::Version ${VERSION} already exists on Galaxy. Set overwrite_existing=true to overwrite."
+          exit 1
 
       - name: Publish to Galaxy
         uses: artis3n/ansible_galaxy_collection@ffbca2460a5a1c600b941bbf1536bd61de1c2227 # v3.0.0
@@ -87,10 +110,7 @@ jobs:
               e.write("RELEASE_DESCRIPTION<<EOF\n%s\nEOF" % description)
 
       - name: Create Release
-        id: create_release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # zizmor: ignore[superfluous-actions] -- Using action for release creation provides better GitHub API integration and version tagging features
-        with:
-          token: ${{ env.GITHUB_TOKEN }}
-          tag_name: ${{ env.VERSION }}
-          name: ${{ env.VERSION }}
-          body: ${{ env.RELEASE_DESCRIPTION }}
+        run: |
+          gh release create "${VERSION}" \
+            --title "${VERSION}" \
+            --notes "${RELEASE_DESCRIPTION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,12 @@ jobs:
         with:
           api_key: ${{ env.GALAXY_API_KEY }}
 
+      - name: Upload collection artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: lowlydba-sqlserver-${{ env.VERSION }}
+          path: ${{ github.workspace }}/lowlydba-sqlserver-${{ env.VERSION }}.tar.gz
+
       - name: Validate version is published to Galaxy
         run: curl --head -s -f -o /dev/null "https://galaxy.ansible.com/download/lowlydba-sqlserver-${VERSION}.tar.gz"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,15 @@ jobs:
       - name: Install PyYaml
         run: pip install pyyaml
 
+      - name: Validate version matches galaxy.yml
+        run: |
+          GALAXY_VERSION=$(python -c "import yaml; print(yaml.safe_load(open('galaxy.yml'))['version'])")
+          if [ "${GALAXY_VERSION}" != "${VERSION}" ]; then
+            echo "::error::Input version '${VERSION}' does not match galaxy.yml version '${GALAXY_VERSION}'."
+            exit 1
+          fi
+          echo "Version ${VERSION} matches galaxy.yml"
+
       - name: Check if version exists on Galaxy
         id: check_galaxy_version
         run: |

--- a/tests/integration/targets/setup_sqlserver_test_plugins/connection_plugins/local_pwsh.py
+++ b/tests/integration/targets/setup_sqlserver_test_plugins/connection_plugins/local_pwsh.py
@@ -68,12 +68,13 @@ class Connection(ConnectionBase):
 
         display.debug("in local_pwsh.exec_command()")
 
-        # mac (darwin) has different pwsh install location than linux
-        if sys.platform.startswith('darwin'):
-            executable = '/usr/local/bin/pwsh'
-        else:
-            executable = '/usr/bin/pwsh'
-        # executable = C.DEFAULT_EXECUTABLE.split()[0] if C.DEFAULT_EXECUTABLE else None
+        # Locate pwsh dynamically; fall back to platform-specific defaults
+        executable = shutil.which('pwsh')
+        if executable is None:
+            if sys.platform.startswith('darwin'):
+                executable = '/usr/local/bin/pwsh'
+            else:
+                executable = '/usr/bin/pwsh'
 
         if not os.path.exists(to_bytes(executable, errors='surrogate_or_strict')):
             raise AnsibleError("failed to find the executable specified %s."


### PR DESCRIPTION


<!-- markdownlint-disable-file -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->


* Added a new `overwrite_existing` boolean input to the release workflow, allowing users to overwrite an existing Galaxy release if needed. The workflow now checks if the specified version already exists and aborts unless overwriting is explicitly enabled.
* Added a validation step to ensure the input version matches the version specified in `galaxy.yml`, preventing accidental mismatches during release.
* Improved artifact handling by uploading the built collection as a workflow artifact after publishing to Galaxy.
* Replaced the use of the `softprops/action-gh-release` action with a direct `gh release create` command for creating GitHub releases, simplifying the release step and reducing dependencies.

* Updated the `local_pwsh.py` test connection plugin to dynamically locate the `pwsh` executable using `shutil.which`, with platform-specific fallbacks, making the test setup more robust across different environments.
   * This fixes the broken dlevel tests - apparently the `pwsh` install directory is more of a moving target these days than when it first came out, so using dynamic resolution is needed as of 2.21+ 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) - Fixes #354 
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read/followed the [**CONTRIBUTING**](https://github.com/LowlyDBA/lowlydba.sqlserver/blob/main/CONTRIBUTING.md) document.
- [x] I have read/followed the [PR Quick Start Guide](https://docs.ansible.com/ansible/devel/community/create_pr_quick_start.html)
- [ ] I have added tests to cover my changes or they are N/A.
- [ ] I have added a [changelog fragment](https://github.com/ansible-community/antsibull-changelog/blob/main/docs/changelogs.rst#changelog-fragment-categories) describing the changes.
- [ ] New module options/parameters include a [`version_added` property](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fields).
