### PR TITLE
ci: add ansible-core stable-2.21 to test matrix, dedupe rollup job names

### DIFF
--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -209,7 +209,7 @@ jobs:
           fail_ci_if_error: false
 
   win-ci-test-rollup:
-    name: Are we good?
+    name: Are we good? (Windows)
     runs-on: ubuntu-slim
     needs: [integration]
     if: always()

--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -55,6 +55,7 @@ jobs:
         ansible:
           - stable-2.19
           - stable-2.20
+          - stable-2.21
           - devel
         python:
           - python3

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -158,7 +158,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }} # zizmor: ignore[secrets-outside-env] -- Codecov token needed for uploading coverage; workflow_dispatch only
 
   ci-test-rollup:
-    name: Are we good?
+    name: Are we good? (Linux)
     runs-on: ubuntu-slim
     needs: [sanity, integration]
     if: always()

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -61,6 +61,7 @@ jobs:
           # Testing against `devel` may fail as new tests are added.
           - stable-2.19
           - stable-2.20
+          - stable-2.21
           - devel
     runs-on: ubuntu-latest
     steps:
@@ -120,6 +121,7 @@ jobs:
         ansible:
           - stable-2.19
           - stable-2.20
+          - stable-2.21
           - devel
         python:
           - 3.10

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ To learn how to maintain / become a maintainer of this collection, refer to the 
 - 2.19
 - 2.20
 - 2.21
-- dlevel
+- devel
 
 ### SQL Server
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ To learn how to maintain / become a maintainer of this collection, refer to the 
 
 - 2.19
 - 2.20
+- 2.21
 - dlevel
 
 ### SQL Server


### PR DESCRIPTION
## Summary

Adds `stable-2.21` to the sanity, integration, and Windows integration test matrices alongside `stable-2.19`, `stable-2.20`, and `devel`.

`stable-2.19` stays for now: per [endoflife.date](https://endoflife.date/ansible-core), its support window still has about 2 months left, so dropping it early would cut coverage before it's actually EOL.

### Also fixed

`ansible-test.yml` and `ansible-test-windows.yml` both had a rollup job named `Are we good?`. Any branch protection rule requiring that check name matches on name alone, so either workflow's run could satisfy it, the Linux and Windows jobs weren't actually both required. Renamed them to `Are we good? (Linux)` and `Are we good? (Windows)`.

> [!IMPORTANT]
> This needs a manual follow-up: update the branch protection required status checks for `main` to use the new names instead of (or alongside) the old `Are we good?` entry.

## Testing

CI runs the updated matrices on this PR.

<!--:robot:-->