### PR TITLE
test/ci: fix win_install_script fixture and devel Python floor

### DIFF
--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -124,6 +124,16 @@ jobs:
             python3-pip
             openssh-client
 
+      # ansible-core devel requires Python >= 3.13 (see pyproject.toml on the devel branch),
+      # which isn't packaged in the Ubuntu-24.04 WSL image used here (default python3 is 3.12).
+      - name: Install Python 3.13 (devel only)  # zizmor: ignore[template-injection] -- matrix.ansible is a controlled enum value (stable-2.19, stable-2.20, devel)
+        if: matrix.ansible == 'devel'
+        run: |
+          sudo add-apt-repository -y ppa:deadsnakes/ppa
+          sudo apt-get update
+          sudo apt-get install -y python3.13 python3.13-venv
+          python3.13 -m ensurepip --upgrade
+
       - name: Get Linux workspace path
         shell: pwsh
         run: |
@@ -153,9 +163,13 @@ jobs:
       # Override break-sys-pkg defaults, because we don't need to bother with python venv for CI
       - name: Install ansible-base (${{ matrix.ansible }})  # zizmor: ignore[template-injection] -- matrix.ansible is a controlled enum value (stable-2.19, stable-2.20, devel)
         run: |
-          python3 -m pip config set global.break-system-packages true
-          python3 -m pip install --upgrade setuptools pypsrp --disable-pip-version-check --retries 10
-          python3 -m pip install "https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz" --disable-pip-version-check --retries 10
+          PYTHON_BIN=python3
+          if [ "${{ matrix.ansible }}" = "devel" ]; then
+            PYTHON_BIN=python3.13
+          fi
+          "$PYTHON_BIN" -m pip config set global.break-system-packages true
+          "$PYTHON_BIN" -m pip install --upgrade setuptools pypsrp --disable-pip-version-check --retries 10
+          "$PYTHON_BIN" -m pip install "https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz" --disable-pip-version-check --retries 10
 
       - name: Install collection dependencies
         id: collection-dependency

--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -126,13 +126,14 @@ jobs:
 
       # ansible-core devel requires Python >= 3.13 (see pyproject.toml on the devel branch),
       # which isn't packaged in the Ubuntu-24.04 WSL image used here (default python3 is 3.12).
-      - name: Install Python 3.13 (devel only)  # zizmor: ignore[template-injection] -- matrix.ansible is a controlled enum value (stable-2.19, stable-2.20, devel)
+      # actions/setup-python only provisions the Windows host, not this WSL guest, so use uv's
+      # standalone Python builds instead of an apt/PPA install.
+      - name: Install Python 3.13 via uv (devel only)  # zizmor: ignore[template-injection] -- matrix.ansible is a controlled enum value (stable-2.19, stable-2.20, devel)
         if: matrix.ansible == 'devel'
         run: |
-          sudo add-apt-repository -y ppa:deadsnakes/ppa
-          sudo apt-get update
-          sudo apt-get install -y python3.13 python3.13-venv
-          python3.13 -m ensurepip --upgrade
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          "$HOME/.local/bin/uv" python install 3.13
+          echo "PYTHON_DEVEL_BIN=$("$HOME/.local/bin/uv" python find 3.13)" >> "$GITHUB_ENV"
 
       - name: Get Linux workspace path
         shell: pwsh
@@ -165,7 +166,7 @@ jobs:
         run: |
           PYTHON_BIN=python3
           if [ "${{ matrix.ansible }}" = "devel" ]; then
-            PYTHON_BIN=python3.13
+            PYTHON_BIN="$PYTHON_DEVEL_BIN"
           fi
           "$PYTHON_BIN" -m pip config set global.break-system-packages true
           "$PYTHON_BIN" -m pip install --upgrade setuptools pypsrp --disable-pip-version-check --retries 10

--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -124,17 +124,6 @@ jobs:
             python3-pip
             openssh-client
 
-      # ansible-core devel requires Python >= 3.13 (see pyproject.toml on the devel branch),
-      # which isn't packaged in the Ubuntu-24.04 WSL image used here (default python3 is 3.12).
-      # actions/setup-python only provisions the Windows host, not this WSL guest, so use uv's
-      # standalone Python builds instead of an apt/PPA install.
-      - name: Install Python 3.13 via uv (devel only)  # zizmor: ignore[template-injection] -- matrix.ansible is a controlled enum value (stable-2.19, stable-2.20, devel)
-        if: matrix.ansible == 'devel'
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          "$HOME/.local/bin/uv" python install 3.13
-          echo "PYTHON_DEVEL_BIN=$("$HOME/.local/bin/uv" python find 3.13)" >> "$GITHUB_ENV"
-
       - name: Get Linux workspace path
         shell: pwsh
         run: |
@@ -162,15 +151,33 @@ jobs:
           Add-Content -LiteralPath $env:GITHUB_ENV -Value "GHWS=$ws"
 
       # Override break-sys-pkg defaults, because we don't need to bother with python venv for CI
+      #
+      # ansible-core devel requires Python >= 3.13 (see pyproject.toml on the devel branch),
+      # which isn't packaged in the Ubuntu-24.04 WSL image used here (default python3 is 3.12).
+      # actions/setup-python only provisions the Windows host, not this WSL guest, so install a
+      # standalone Python 3.13 via uv for that leg instead of an apt/PPA install.
       - name: Install ansible-base (${{ matrix.ansible }})  # zizmor: ignore[template-injection] -- matrix.ansible is a controlled enum value (stable-2.19, stable-2.20, devel)
         run: |
           PYTHON_BIN=python3
           if [ "${{ matrix.ansible }}" = "devel" ]; then
-            PYTHON_BIN="$PYTHON_DEVEL_BIN"
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+            "$HOME/.local/bin/uv" python install 3.13
+            PYTHON_BIN="$("$HOME/.local/bin/uv" python find 3.13)"
           fi
           "$PYTHON_BIN" -m pip config set global.break-system-packages true
           "$PYTHON_BIN" -m pip install --upgrade setuptools pypsrp --disable-pip-version-check --retries 10
           "$PYTHON_BIN" -m pip install "https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz" --disable-pip-version-check --retries 10
+          if [ "${{ matrix.ansible }}" = "devel" ]; then
+            # uv's standalone Python isn't on PATH, and its console scripts don't land in
+            # /usr/local/bin like the system python3 case does, so symlink them there for later
+            # wsl-bash steps (each one is a fresh --norc/--noprofile shell, nothing persists).
+            BIN_DIR="$(dirname "$PYTHON_BIN")"
+            for SCRIPT in ansible ansible-config ansible-console ansible-doc ansible-galaxy ansible-inventory ansible-playbook ansible-pull ansible-vault ansible-test; do
+              if [ -x "$BIN_DIR/$SCRIPT" ]; then
+                ln -sf "$BIN_DIR/$SCRIPT" "/usr/local/bin/$SCRIPT"
+              fi
+            done
+          fi
 
       - name: Install collection dependencies
         id: collection-dependency

--- a/tests/integration/targets/win_install_script/files/2-select-choice.sql
+++ b/tests/integration/targets/win_install_script/files/2-select-choice.sql
@@ -1,0 +1,1 @@
+SELECT 'another choice';


### PR DESCRIPTION
Fixes #371. Fixes #373.

`ansible.windows.win_copy` crashes with `cannot access local variable 'source_full' where it is not associated with a value` when copying a source directory that contains exactly one file ([ansible-collections/ansible.windows#157](https://github.com/ansible-collections/ansible.windows/issues/157)). `tests/integration/targets/win_install_script/files/` had only `1-select-choice.sql`, so every CI run on Windows hit the buggy path in the `Copy migration script(s)` task. Adding a second script file avoids that code path.

Separately, `ansible-core`'s devel branch now requires Python `>=3.13` (see its [pyproject.toml](https://github.com/ansible/ansible/blob/devel/pyproject.toml)), but `ansible-test-windows.yml` installs it with whatever `python3` ships in the `Ubuntu-24.04` WSL image, which is Python 3.12. That fails the `pip install` step outright for the `devel` matrix leg.

> [!NOTE]
> `actions/setup-python` can't fix this: it provisions the job's runner OS (`windows-2022` here), and our `wsl-bash` steps run inside a separate WSL guest that action never touches. Bumping the Windows runner image wouldn't help either, since the guest's Python comes from `Vampire/setup-wsl`'s `Ubuntu-24.04` distribution image (still 3.12), which is independent of the host OS and is already the newest distro that action supports.

Installing `python3.13` via `uv python install` inside the WSL guest for the `devel` leg avoids both dead ends, no `sudo`/PPA needed.

No module behavior changes in either fix, so no changelog fragment.

## Testing

Can't repro either locally (no Windows SQL Server target or WSL in this environment). Verification is the next Windows CI run on this PR, in particular the `devel` matrix leg for the Python fix.

<!--:robot:-->
