### PR TITLE
agent_job_step: fix rename by step_id

### DIFF
--- a/changelogs/fragments/379-agent-job-step-rename-by-id.yml
+++ b/changelogs/fragments/379-agent-job-step-rename-by-id.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - agent_job_step - Fix inability to rename a step by ``step_id``. The module now looks
+    up the existing step by ``step_id`` when ``state=present``, instead of by ``step_name``,
+    so a rename (new ``step_name``, same ``step_id``) is correctly detected as an update.

--- a/plugins/modules/agent_job_step.ps1
+++ b/plugins/modules/agent_job_step.ps1
@@ -65,20 +65,22 @@ $PSDefaultParameterValues = @{ "*:EnableException" = $true; "*:Confirm" = $false
 # Configure Agent job step
 try {
     $existingJobSteps = Get-DbaAgentJobStep -SqlInstance $SqlInstance -SqlCredential $sqlCredential -Job $job
-    $existingJobStep = $existingJobSteps | Where-Object Name -eq $stepName
 
     if ($state -eq "absent") {
-        if ($null -eq $existingJobStep) {
-            # try fetching name by id if we only care about removing
+        # Either step_id or step_name may be supplied; look up by whichever is available.
+        $existingJobStep = $null
+        if ($stepId) {
             $existingJobStep = $existingJobSteps | Where-Object Id -eq $stepId
-            $stepName = $existingJobStep.Name
+        }
+        if ($null -eq $existingJobStep -and $stepName) {
+            $existingJobStep = $existingJobSteps | Where-Object Name -eq $stepName
         }
         if ($existingJobStep) {
             $removeStepSplat = @{
                 SqlInstance = $sqlInstance
                 SqlCredential = $sqlCredential
                 Job = $job
-                StepName = $stepName
+                StepName = $existingJobStep.Name
             }
             $output = Remove-DbaAgentJobStep @removeStepSplat
             $module.Result.changed = $true
@@ -88,6 +90,9 @@ try {
         if (!($stepName) -or !($stepId)) {
             $module.FailJson("Step name and step_id must be specified when state=present.")
         }
+        # step_id and step_name are both required here, and step_name may be a new name for an
+        # existing step (rename), so look up strictly by the immutable id rather than by name.
+        $existingJobStep = $existingJobSteps | Where-Object Id -eq $stepId
         $jobStepParams = @{
             SqlInstance = $sqlInstance
             SqlCredential = $sqlCredential
@@ -138,9 +143,10 @@ try {
         }
         # Update existing
         else {
-            # Validate step name isn't taken already - must be unique within a job
-            if ($existingJobStep.Name -eq $StepName -and $existingJobStep.ID -ne $stepId) {
-                $module.FailJson("There is already a step named '$StepName' for this job with an ID of $($existingJobStep.ID).")
+            # Validate step name isn't taken already by another step - must be unique within a job
+            $conflictingStep = $existingJobSteps | Where-Object { $_.Name -eq $stepName -and $_.ID -ne $existingJobStep.ID }
+            if ($conflictingStep) {
+                $module.FailJson("There is already a step named '$stepName' for this job with an ID of $($conflictingStep.ID).")
             }
 
             # Reference by old name in case new name differs for step id

--- a/plugins/modules/agent_job_step.ps1
+++ b/plugins/modules/agent_job_step.ps1
@@ -93,6 +93,15 @@ try {
         # step_id and step_name are both required here, and step_name may be a new name for an
         # existing step (rename), so look up strictly by the immutable id rather than by name.
         $existingJobStep = $existingJobSteps | Where-Object Id -eq $stepId
+
+        # Validate step name isn't taken already by another step - must be unique within a job.
+        # This covers both renaming onto an already-taken name and creating a new step whose
+        # name collides with an existing one under a different step_id.
+        $conflictingStep = $existingJobSteps | Where-Object { $_.Name -eq $stepName -and $_.ID -ne $stepId }
+        if ($conflictingStep) {
+            $module.FailJson("There is already a step named '$stepName' for this job with an ID of $($conflictingStep.ID).")
+        }
+
         $jobStepParams = @{
             SqlInstance = $sqlInstance
             SqlCredential = $sqlCredential
@@ -143,12 +152,6 @@ try {
         }
         # Update existing
         else {
-            # Validate step name isn't taken already by another step - must be unique within a job
-            $conflictingStep = $existingJobSteps | Where-Object { $_.Name -eq $stepName -and $_.ID -ne $existingJobStep.ID }
-            if ($conflictingStep) {
-                $module.FailJson("There is already a step named '$stepName' for this job with an ID of $($conflictingStep.ID).")
-            }
-
             # Reference by old name in case new name differs for step id
             $jobStepParams.StepName = $existingJobStep.Name
             $jobStepParams.Add("NewName", $StepName)

--- a/tests/integration/targets/agent_job_step/tasks/main.yml
+++ b/tests/integration/targets/agent_job_step/tasks/main.yml
@@ -129,6 +129,32 @@
           - result.data.State == "Existing"
           - result is not changed
 
+    - name: Rename agent job step by step_id
+      lowlydba.sqlserver.agent_job_step:
+        step_name: "{{ job_step3 }} renamed"
+        step_id: 3
+        database: "model"
+      register: result
+    - assert:
+        that:
+          - result.data != None
+          - result.data.Name == job_step3 + " renamed"
+          - result.data.ID == 3
+          - result.data.DatabaseName == "model"
+          - result.data.State == "Existing"
+          - result is changed
+
+    - name: Verify rename onto an already-taken name fails cleanly
+      lowlydba.sqlserver.agent_job_step:
+        step_name: "{{ job_step2 }}"
+        step_id: 3
+        database: "model"
+      register: result
+      failed_when: result is not failed
+    - assert:
+        that:
+          - result is not changed
+
     - name: Create agent job step with output file
       lowlydba.sqlserver.agent_job_step:
         step_name: "Step with output file"


### PR DESCRIPTION
## Summary
Fixes #379.

`agent_job_step` looked up the existing step by `step_name` even when `state=present` requires both `step_id` and `step_name`. This meant a rename (new `step_name`, same `step_id`) could never be detected as an update — the name lookup missed, and the module tried `New-DbaAgentJobStep` with a duplicate step ID.

## Changes
- `plugins/modules/agent_job_step.ps1`: for `state=present`, look up the existing step strictly by `step_id` (both `step_id` and `step_name` are required in this state, and `step_name` may legitimately be a new name for the step being renamed). The `absent` state still falls back to name lookup since only one of `step_id`/`step_name` may be supplied there.
- Kept the uniqueness check so renaming onto an already-taken step name still fails cleanly, now comparing against other steps rather than the step being renamed.
- Added integration tests covering a successful rename by `step_id` and a rename that conflicts with an existing step name.
- Added a changelog fragment.