### PR TITLE
fix: ag_listener reconciles IP/subnet/DHCP on existing listeners

### DIFF
--- a/changelogs/fragments/376-ag-listener-ip-reconcile.yml
+++ b/changelogs/fragments/376-ag-listener-ip-reconcile.yml
@@ -1,3 +1,6 @@
 bugfixes:
-  - ag_listener - Reconcile IP address, subnet mask, and DHCP settings against an existing listener instead of only
-    checking the port. Since these cannot be altered in place, a mismatch drops and re-creates the listener (#376).
+  - ag_listener - ``ip_address``, ``subnet_mask`` and ``dhcp`` were only used when creating a new listener, so
+    changing them on an existing listener reported no change and left it untouched. These settings can't be
+    altered in place, so a mismatch between the requested and current IP configuration now drops and re-creates
+    the listener via ``Remove-DbaAgListener`` and ``Add-DbaAgListener``
+    (https://github.com/lowlydba/lowlydba.sqlserver/issues/376).

--- a/changelogs/fragments/376-ag-listener-ip-reconcile.yml
+++ b/changelogs/fragments/376-ag-listener-ip-reconcile.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ag_listener - Reconcile IP address, subnet mask, and DHCP settings against an existing listener instead of only
+    checking the port. Since these cannot be altered in place, a mismatch drops and re-creates the listener (#376).

--- a/plugins/modules/ag_listener.ps1
+++ b/plugins/modules/ag_listener.ps1
@@ -99,14 +99,15 @@ function Test-ListenerIpMismatch {
         # Caller did not request management of IP/DHCP settings, leave as-is.
         return $false
     }
-    $existingIps = @($ExistingListener.AvailabilityGroupListenerIPAddresses | ForEach-Object {
-        if ($_.IsDHCP) {
-            [PSCustomObject]@{ IsDhcp = $true; IPAddress = $null; SubnetMask = $null }
+    $existingIps = @()
+    foreach ($existingIp in $ExistingListener.AvailabilityGroupListenerIPAddresses) {
+        if ($existingIp.IsDHCP) {
+            $existingIps += [PSCustomObject]@{ IsDhcp = $true; IPAddress = $null; SubnetMask = $null }
         }
         else {
-            [PSCustomObject]@{ IsDhcp = $false; IPAddress = [string]$_.IPAddress; SubnetMask = [string]$_.SubnetMask }
+            $existingIps += [PSCustomObject]@{ IsDhcp = $false; IPAddress = [string]$existingIp.IPAddress; SubnetMask = [string]$existingIp.SubnetMask }
         }
-    })
+    }
     if ($existingIps.Count -ne $DesiredIps.Count) {
         return $true
     }

--- a/plugins/modules/ag_listener.ps1
+++ b/plugins/modules/ag_listener.ps1
@@ -43,29 +43,116 @@ $PSDefaultParameterValues = @{
     "*:WhatIf" = $checkMode
 }
 
+function Get-DesiredListenerIp {
+    <#
+        .SYNOPSIS
+        Normalizes the desired IP configuration for a listener based on module params.
+
+        .DESCRIPTION
+        Mirrors the IP/SubnetMask pairing logic used by Add-DbaAgListener so the desired
+        state can be compared against what already exists on the server.
+    #>
+    param(
+        [AllowNull()][string[]]$IpAddress,
+        [AllowNull()][string[]]$SubnetMask,
+        [bool]$Dhcp
+    )
+    if ($Dhcp) {
+        return , [PSCustomObject]@{ IsDhcp = $true; IPAddress = $null; SubnetMask = $null }
+    }
+    if ($null -eq $IpAddress) {
+        return @()
+    }
+    $masks = $SubnetMask
+    if ($null -eq $masks -or $masks.Count -eq 0) {
+        $masks = , '255.255.255.0'
+    }
+    if ($masks.Count -eq 1 -and $IpAddress.Count -gt 1) {
+        $masks = @($masks[0]) * $IpAddress.Count
+    }
+    $desired = @()
+    for ($i = 0; $i -lt $IpAddress.Count; $i++) {
+        $desired += [PSCustomObject]@{
+            IsDhcp = $false
+            IPAddress = [string]$IpAddress[$i]
+            SubnetMask = [string]$masks[$i]
+        }
+    }
+    return $desired
+}
+
+function Test-ListenerIpMismatch {
+    <#
+        .SYNOPSIS
+        Compares the listener's current IP configuration against the desired state.
+
+        .DESCRIPTION
+        Returns $true when the existing listener's IP addresses/subnet masks/DHCP
+        setting differ from the desired configuration. Listener IPs can't be altered
+        in place, so a mismatch means the listener must be dropped and re-created.
+    #>
+    param(
+        $ExistingListener,
+        [array]$DesiredIps
+    )
+    if ($DesiredIps.Count -eq 0) {
+        # Caller did not request management of IP/DHCP settings, leave as-is.
+        return $false
+    }
+    $existingIps = @($ExistingListener.AvailabilityGroupListenerIPAddresses | ForEach-Object {
+        if ($_.IsDHCP) {
+            [PSCustomObject]@{ IsDhcp = $true; IPAddress = $null; SubnetMask = $null }
+        }
+        else {
+            [PSCustomObject]@{ IsDhcp = $false; IPAddress = [string]$_.IPAddress; SubnetMask = [string]$_.SubnetMask }
+        }
+    })
+    if ($existingIps.Count -ne $DesiredIps.Count) {
+        return $true
+    }
+    if ($DesiredIps[0].IsDhcp) {
+        return -not ($existingIps | Where-Object { $_.IsDhcp })
+    }
+    if ($existingIps | Where-Object { $_.IsDhcp }) {
+        return $true
+    }
+    $existingSet = @($existingIps | ForEach-Object { "$($_.IPAddress)|$($_.SubnetMask)" } | Sort-Object)
+    $desiredSet = @($DesiredIps | ForEach-Object { "$($_.IPAddress)|$($_.SubnetMask)" } | Sort-Object)
+    return [bool](Compare-Object -ReferenceObject $existingSet -DifferenceObject $desiredSet)
+}
+
 try {
     $existingListener = Get-DbaAgListener -AvailabilityGroup $agName -Listener $listenerName
     if ($state -eq "present") {
+        $listenerParams = @{
+            AvailabilityGroup = $agName
+            Name = $listenerName
+            Port = $port
+            Dhcp = $dhcp
+            SubnetMask = $subnetMask
+        }
+        if ($null -ne $ipAddress) {
+            $listenerParams.Add("IPAddress", $ipAddress)
+        }
+        if ($null -ne $subnetIp) {
+            $listenerParams.Add("SubnetIP", $subnetIp)
+        }
         if ($null -eq $existingListener) {
-            $listenerParams = @{
-                AvailabilityGroup = $agName
-                Name = $listenerName
-                Port = $port
-                Dhcp = $dhcp
-                SubnetMask = $subnetMask
-            }
-            if ($null -ne $ipAddress) {
-                $listenerParams.Add("IPAddress", $ipAddress)
-            }
-            if ($null -ne $subnetIp) {
-                $listenerParams.Add("SubnetIP", $subnetIp)
-            }
             $output = Add-DbaAgListener @listenerParams
             $module.Result.changed = $true
         }
-        elseif ($existingListener.PortNumber -ne $port) {
-            $output = Set-DbaAgListener -AvailabilityGroup $agName -Listener $listenerName -Port $port
-            $module.Result.changed = $true
+        else {
+            $desiredIps = Get-DesiredListenerIp -IpAddress $ipAddress -SubnetMask $subnetMask -Dhcp $dhcp
+            if (Test-ListenerIpMismatch -ExistingListener $existingListener -DesiredIps $desiredIps) {
+                # IP addresses/DHCP cannot be altered in place, drop and re-create the listener.
+                $null = Remove-DbaAgListener -AvailabilityGroup $agName -Listener $listenerName
+                $output = Add-DbaAgListener @listenerParams
+                $module.Result.changed = $true
+            }
+            elseif ($existingListener.PortNumber -ne $port) {
+                $output = Set-DbaAgListener -AvailabilityGroup $agName -Listener $listenerName -Port $port
+                $module.Result.changed = $true
+            }
         }
     }
     elseif ($state -eq "absent") {

--- a/plugins/modules/ag_listener.ps1
+++ b/plugins/modules/ag_listener.ps1
@@ -49,16 +49,17 @@ function Get-DesiredListenerIp {
         Normalizes the desired IP configuration for a listener based on module params.
 
         .DESCRIPTION
-        Mirrors the IP/SubnetMask pairing logic used by Add-DbaAgListener so the desired
-        state can be compared against what already exists on the server.
+        Mirrors the IP/SubnetMask/SubnetIP pairing logic used by Add-DbaAgListener so the
+        desired state can be compared against what already exists on the server.
     #>
     param(
         [AllowNull()][string[]]$IpAddress,
+        [AllowNull()][string[]]$SubnetIp,
         [AllowNull()][string[]]$SubnetMask,
         [bool]$Dhcp
     )
     if ($Dhcp) {
-        return , [PSCustomObject]@{ IsDhcp = $true; IPAddress = $null; SubnetMask = $null }
+        return , [PSCustomObject]@{ IsDhcp = $true; IPAddress = $null; SubnetMask = $null; SubnetIP = $null }
     }
     if ($null -eq $IpAddress) {
         return @()
@@ -70,12 +71,23 @@ function Get-DesiredListenerIp {
     if ($masks.Count -eq 1 -and $IpAddress.Count -gt 1) {
         $masks = @($masks[0]) * $IpAddress.Count
     }
+    $subnets = $SubnetIp
+    if ($null -eq $subnets -or $subnets.Count -eq 0) {
+        # No subnet IPs supplied, calculate them from the IP/mask pairs like Add-DbaAgListener does.
+        $subnets = for ($i = 0; $i -lt $IpAddress.Count; $i++) {
+            (([ipaddress]$IpAddress[$i]).Address -band ([ipaddress]$masks[$i]).Address) -as [ipaddress]
+        }
+    }
+    elseif ($subnets.Count -eq 1 -and $IpAddress.Count -gt 1) {
+        $subnets = @($subnets[0]) * $IpAddress.Count
+    }
     $desired = @()
     for ($i = 0; $i -lt $IpAddress.Count; $i++) {
         $desired += [PSCustomObject]@{
             IsDhcp = $false
             IPAddress = [string]$IpAddress[$i]
             SubnetMask = [string]$masks[$i]
+            SubnetIP = [string]$subnets[$i]
         }
     }
     return $desired
@@ -87,7 +99,7 @@ function Test-ListenerIpMismatch {
         Compares the listener's current IP configuration against the desired state.
 
         .DESCRIPTION
-        Returns $true when the existing listener's IP addresses/subnet masks/DHCP
+        Returns $true when the existing listener's IP addresses/subnet masks/subnet IPs/DHCP
         setting differ from the desired configuration. Listener IPs can't be altered
         in place, so a mismatch means the listener must be dropped and re-created.
     #>
@@ -102,10 +114,15 @@ function Test-ListenerIpMismatch {
     $existingIps = @()
     foreach ($existingIp in $ExistingListener.AvailabilityGroupListenerIPAddresses) {
         if ($existingIp.IsDHCP) {
-            $existingIps += [PSCustomObject]@{ IsDhcp = $true; IPAddress = $null; SubnetMask = $null }
+            $existingIps += [PSCustomObject]@{ IsDhcp = $true; IPAddress = $null; SubnetMask = $null; SubnetIP = $null }
         }
         else {
-            $existingIps += [PSCustomObject]@{ IsDhcp = $false; IPAddress = [string]$existingIp.IPAddress; SubnetMask = [string]$existingIp.SubnetMask }
+            $existingIps += [PSCustomObject]@{
+                IsDhcp = $false
+                IPAddress = [string]$existingIp.IPAddress
+                SubnetMask = [string]$existingIp.SubnetMask
+                SubnetIP = [string]$existingIp.SubnetIP
+            }
         }
     }
     if ($existingIps.Count -ne $DesiredIps.Count) {
@@ -117,8 +134,8 @@ function Test-ListenerIpMismatch {
     if ($existingIps | Where-Object { $_.IsDhcp }) {
         return $true
     }
-    $existingSet = @($existingIps | ForEach-Object { "$($_.IPAddress)|$($_.SubnetMask)" } | Sort-Object)
-    $desiredSet = @($DesiredIps | ForEach-Object { "$($_.IPAddress)|$($_.SubnetMask)" } | Sort-Object)
+    $existingSet = @($existingIps | ForEach-Object { "$($_.IPAddress)|$($_.SubnetMask)|$($_.SubnetIP)" } | Sort-Object)
+    $desiredSet = @($DesiredIps | ForEach-Object { "$($_.IPAddress)|$($_.SubnetMask)|$($_.SubnetIP)" } | Sort-Object)
     return [bool](Compare-Object -ReferenceObject $existingSet -DifferenceObject $desiredSet)
 }
 
@@ -143,7 +160,7 @@ try {
             $module.Result.changed = $true
         }
         else {
-            $desiredIps = Get-DesiredListenerIp -IpAddress $ipAddress -SubnetMask $subnetMask -Dhcp $dhcp
+            $desiredIps = Get-DesiredListenerIp -IpAddress $ipAddress -SubnetIp $subnetIp -SubnetMask $subnetMask -Dhcp $dhcp
             if (Test-ListenerIpMismatch -ExistingListener $existingListener -DesiredIps $desiredIps) {
                 # IP addresses/DHCP cannot be altered in place, drop and re-create the listener.
                 $null = Remove-DbaAgListener -AvailabilityGroup $agName -Listener $listenerName

--- a/plugins/modules/ag_listener.py
+++ b/plugins/modules/ag_listener.py
@@ -25,6 +25,8 @@ options:
   ip_address:
     description:
       - IP address(es) of the listener. Comma separated if multiple.
+      - If this differs from the listener's current IP address(es), the listener is dropped and re-created since
+        IP addresses cannot be altered in place.
     type: list
     elements: str
     required: false
@@ -37,6 +39,7 @@ options:
   subnet_mask:
     description:
       - Sets the subnet IP mask(s) of the availability group listener. Comma separated if multiple.
+      - Only reconciled against an existing listener when C(ip_address) is also supplied.
     type: list
     elements: str
     required: false
@@ -50,6 +53,8 @@ options:
   dhcp:
     description:
       - Indicates whether the listener uses DHCP.
+      - If this differs from the listener's current configuration, the listener is dropped and re-created since
+        this cannot be altered in place.
     type: bool
     required: false
     default: false
@@ -85,7 +90,7 @@ EXAMPLES = r'''
 
 RETURN = r'''
 data:
-  description: Output from the C(Add-DbaAgListener) or C(Set-DbaAgListener) function.
+  description: Output from the C(Add-DbaAgListener), C(Set-DbaAgListener), or C(Remove-DbaAgListener)/C(Add-DbaAgListener) function.
   returned: success, but not in check_mode.
   type: dict
 '''

--- a/plugins/modules/ag_listener.py
+++ b/plugins/modules/ag_listener.py
@@ -33,6 +33,7 @@ options:
   subnet_ip:
     description:
       - Subnet IP address(es) of the listener. Comma separated if multiple.
+      - Only reconciled against an existing listener when C(ip_address) is also supplied.
     type: list
     elements: str
     required: false
@@ -90,7 +91,8 @@ EXAMPLES = r'''
 
 RETURN = r'''
 data:
-  description: Output from the C(Add-DbaAgListener), C(Set-DbaAgListener), or C(Remove-DbaAgListener)/C(Add-DbaAgListener) function.
+  description: Output from the C(Add-DbaAgListener) or C(Set-DbaAgListener) function. When an existing listener's
+    IP/DHCP configuration is reconciled, this is the output of the C(Add-DbaAgListener) call used to re-create it.
   returned: success, but not in check_mode.
   type: dict
 '''

--- a/plugins/modules/ag_listener.py
+++ b/plugins/modules/ag_listener.py
@@ -33,14 +33,16 @@ options:
   subnet_ip:
     description:
       - Subnet IP address(es) of the listener. Comma separated if multiple.
-      - Only reconciled against an existing listener when C(ip_address) is also supplied.
+      - Only reconciled against an existing listener when C(ip_address) is also supplied. Has no effect and is
+        not reconciled when C(dhcp=true).
     type: list
     elements: str
     required: false
   subnet_mask:
     description:
       - Sets the subnet IP mask(s) of the availability group listener. Comma separated if multiple.
-      - Only reconciled against an existing listener when C(ip_address) is also supplied.
+      - Only reconciled against an existing listener when C(ip_address) is also supplied. Has no effect and is
+        not reconciled when C(dhcp=true).
     type: list
     elements: str
     required: false


### PR DESCRIPTION
`ip_address`, `subnet_ip`, `subnet_mask`, and `dhcp` were only used when creating a new listener. Running the module against an existing listener with a different IP or DHCP setting reported `changed: false` and left the listener untouched, fixes #376.

Listener IPs can't be altered in place, so a mismatch now drops and re-creates the listener via `Remove-DbaAgListener`/`Add-DbaAgListener` instead of silently no-opping. Port-only changes still go through `Set-DbaAgListener` as before.

IP reconciliation only kicks in when `ip_address` or `dhcp: true` is actually supplied. `subnet_mask` carries a spec-level default of `255.255.255.0`, so it can't be used to detect intent on its own; without `ip_address`/`dhcp`, the module still only manages port, matching prior behavior for callers who never touch IP config.

## Testing

No integration test target exists for `ag_listener` yet and this repo's integration tests need a live SQL Server instance, so I validated the new comparison logic (`Get-DesiredListenerIp`/`Test-ListenerIpMismatch`) with standalone PowerShell unit checks against mock listener objects (matching IPs, mismatched IPs, DHCP requested vs static, DHCP requested vs existing DHCP). I didn't add an integration test target for this module since one didn't exist before.
<!--:robot:-->