### PR TITLE
fix: raise requires_ansible floor to match tested CI matrix

### DIFF
--- a/changelogs/fragments/380-requires-ansible-floor.yml
+++ b/changelogs/fragments/380-requires-ansible-floor.yml
@@ -1,0 +1,4 @@
+breaking_changes:
+  - Raise ``requires_ansible`` to ``>=2.19``. The previously declared floor of ``>=2.12`` was never
+    tested by CI, which only runs sanity and integration tests against ``stable-2.19`` and newer
+    (https://github.com/lowlydba/lowlydba.sqlserver/issues/380).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.12"
+requires_ansible: ">=2.19"


### PR DESCRIPTION
`meta/runtime.yml` declared `requires_ansible: ">=2.12"`, but `.github/workflows/ansible-test.yml` only runs sanity and integration against `stable-2.19`, `stable-2.20`, `stable-2.21`, and `devel`. Nothing tested 2.12 through 2.18, so the floor was a claim, not a guarantee.

Raises the floor to `>=2.19` to match what CI actually tests. The README's Tested with section already listed 2.19+, so this just brings `meta/runtime.yml` in line with it.

Added a `breaking_changes` fragment since this is a floor bump for consumers on older `ansible-core`.

Fixes #380

## Testing

No test covers `requires_ansible` directly, this is a metadata-only change. CI's sanity/integration matrix (`stable-2.19` through `devel`) is the existing verification that the new floor holds.

<!--:robot:-->