### PR TITLE
ci: upgrade CI to SQL Server 2025

### DIFF
--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -208,7 +208,7 @@ jobs:
         with:
           install: sqlengine
           sa-password: L0wlydb4
-          version: 2022
+          version: 2025
 
       - name: Retry SQL Server install
         id: retry1
@@ -217,7 +217,7 @@ jobs:
         with:
           install: sqlengine
           sa-password: L0wlydb4
-          version: 2022
+          version: 2025
 
       - name: Run integration test  # zizmor: ignore[template-injection] -- env.GHWS is a computed path; matrix values are controlled enums
         run: |

--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -132,27 +132,10 @@ jobs:
       - name: Get Linux workspace path
         shell: pwsh
         run: |
-          # $ws = & wslpath --% -u -a "$env:WORKSPACE""
-          # seems wslpath is not available on server 2019
-
-          function ConvertTo-LinuxPathCrappy {
-              [CmdletBinding()]
-              param(
-                  [Parameter(Mandatory)]
-                  [ValidateNotNullOrEmpty()]
-                  [string]
-                  $LiteralPath
-              )
-
-              End {
-                  $resolved = Resolve-Path -LiteralPath $LiteralPath
-                  $drive = ($resolved | Split-Path -Qualifier).TrimEnd(':').ToLower()
-                  $rooted = ($resolved | Split-Path -NoQualifier).Replace('\', '/').TrimStart('/')
-
-                  '/mnt/{0}/{1}' -f $drive, $rooted
-              }
-          }
-          $ws = ConvertTo-LinuxPathCrappy -LiteralPath "$env:WORKSPACE"
+          # Calling wsl.exe's wslpath directly from pwsh (`wsl wslpath ...`) mangles the
+          # path (drops separators) due to a known argument-encoding issue between pwsh
+          # and wsl.exe. Routing through `wsl bash -c` avoids it.
+          $ws = wsl bash -c "wslpath -u -a '$env:WORKSPACE'"
           Add-Content -LiteralPath $env:GITHUB_ENV -Value "GHWS=$ws"
 
       # Override break-sys-pkg defaults, because we don't need to bother with python venv for CI

--- a/.github/workflows/ansible-test-windows.yml
+++ b/.github/workflows/ansible-test-windows.yml
@@ -80,7 +80,6 @@ jobs:
       GROUP: ${{ matrix.group }}  # zizmor: ignore[template-injection] -- Matrix value from controlled environment
       PYTHON: python3
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}  # zizmor: ignore[secrets-outside-env] -- Codecov token needed for coverage uploads; environment protection would block PR-triggered runs
-      WORKSPACE: ${{ github.workspace }}
 
     steps:
       - name: Check out code
@@ -129,15 +128,6 @@ jobs:
           done
           exit 1
 
-      - name: Get Linux workspace path
-        shell: pwsh
-        run: |
-          # Calling wsl.exe's wslpath directly from pwsh (`wsl wslpath ...`) mangles the
-          # path (drops separators) due to a known argument-encoding issue between pwsh
-          # and wsl.exe. Routing through `wsl bash -c` avoids it.
-          $ws = wsl bash -c "wslpath -u -a '$env:WORKSPACE'"
-          Add-Content -LiteralPath $env:GITHUB_ENV -Value "GHWS=$ws"
-
       # Override break-sys-pkg defaults, because we don't need to bother with python venv for CI
       #
       # ansible-core devel requires Python >= 3.13 (see pyproject.toml on the devel branch),
@@ -169,14 +159,12 @@ jobs:
 
       - name: Install collection dependencies
         id: collection-dependency
-        # zizmor: ignore[template-injection] -- GHWS is dynamically computed earlier in the workflow
-        run: ansible-galaxy collection install ansible.windows -p "${{ env.GHWS }}"
+        run: ansible-galaxy collection install ansible.windows -p "$PWD"
         continue-on-error: true
 
       - name: Retry install collection dependencies
         if: steps.collection-dependency.outcome == 'failure'
-        # zizmor: ignore[template-injection] -- GHWS is dynamically computed earlier in the workflow
-        run: ansible-galaxy collection install ansible.windows -p "${{ env.GHWS }}"
+        run: ansible-galaxy collection install ansible.windows -p "$PWD"
 
       - name: Set integration test options
         working-directory: ./ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}/tests/integration
@@ -202,15 +190,13 @@ jobs:
           sa-password: L0wlydb4
           version: 2025
 
-      - name: Run integration test  # zizmor: ignore[template-injection] -- env.GHWS is a computed path; matrix values are controlled enums
-        run: |
-          pushd "${{ env.GHWS }}/ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}"
-          ansible-test windows-integration -v --color --retry-on-error --continue-on-error --diff --coverage --requirements windows/group/${{ matrix.group }}/
+      - name: Run integration test  # zizmor: ignore[template-injection] -- matrix values are controlled enums
+        working-directory: ./ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
+        run: ansible-test windows-integration -v --color --retry-on-error --continue-on-error --diff --coverage --requirements windows/group/${{ matrix.group }}/
 
-      - name: Generate coverage report  # zizmor: ignore[template-injection] -- env.GHWS is a computed path
-        run: |
-          pushd "${{ env.GHWS }}/ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}"
-          ansible-test coverage xml -v --requirements
+      - name: Generate coverage report
+        working-directory: ./ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
+        run: ansible-test coverage xml -v --requirements
 
       # See the reports at https://codecov.io/gh/lowlydba/lowlydba.sqlserver
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -138,7 +138,7 @@ jobs:
       contents: write  # Required for uploading coverage reports
     services:
       sqlserver:
-        image: mcr.microsoft.com/mssql/server:2022-latest # zizmor: ignore[unpinned-images] -- Trusted publisher for this CI use case
+        image: mcr.microsoft.com/mssql/server:2025-latest # zizmor: ignore[unpinned-images] -- Trusted publisher for this CI use case
         ports:
           - 1433:1433
         env:


### PR DESCRIPTION
Bumps CI to SQL Server 2025 (latest stable).

- `ansible-test-windows.yml`: `version: 2025` for both the primary and retry `potatoqualitee/mssqlsuite` steps. Already pinned to `v1.12`, the latest action release, so no action version bump needed.
- `ansible-test.yml`: Linux integration container image to `mcr.microsoft.com/mssql/server:2025-latest`.

Also dropped the `Get Linux workspace path` step entirely. It computed a `GHWS` env var (a hand-translated `/mnt/c/...` path) so later `wsl-bash` steps could `pushd` into the right directory. Turns out that's unnecessary: `wsl.exe` auto-translates the invoking Windows cwd to its DrvFs-mounted equivalent, so a `working-directory:` pointing at the Windows-style repo path (same as the existing `Set integration test options` step already did) lands `wsl-bash` steps in the right place with no extra computation. Verified locally: `cd <windows-path>; wsl bash -c pwd` returns the matching `/mnt/c/...` path directly.

## Testing

CI is the validity check here; no local SQL Server run.

<!--:robot:-->