### PR TITLE
docs: add missing v3.1.0 release summary

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ lowlydba.sqlserver Release Notes
 v3.1.0
 ======
 
+Release Summary
+---------------
+
+This release fixes two ``changed``-reporting bugs (``availability_group`` incorrectly reporting ``changed=true`` on an unchanged AG, and ``backup``/``restore`` incorrectly reporting ``changed=false`` under ``check_mode``), adds a Pester unit test suite for the shared ``module_utils`` helpers, closes integration test gaps for ``availability_group``, ``ag_replica``, ``backup``, ``restore`` and ``install_script``, and standardizes module documentation examples.
+
 Minor Changes
 -------------
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -740,6 +740,12 @@ releases:
     release_date: '2026-09-04'
   3.1.0:
     changes:
+      release_summary: This release fixes two ``changed``-reporting bugs (``availability_group``
+        incorrectly reporting ``changed=true`` on an unchanged AG, and ``backup``/``restore``
+        incorrectly reporting ``changed=false`` under ``check_mode``), adds a Pester
+        unit test suite for the shared ``module_utils`` helpers, closes integration
+        test gaps for ``availability_group``, ``ag_replica``, ``backup``, ``restore``
+        and ``install_script``, and standardizes module documentation examples.
       bugfixes:
       - availability_group - Fix ``changed`` being incorrectly reported as ``true``
         on an unchanged AG. ``Get-DbaAvailabilityGroup``'s SMO object never populates


### PR DESCRIPTION
The `3.1.0` release was cut without a `release_summary` fragment, so `changelogs/changelog.yaml` and `CHANGELOG.rst` both skip straight to `Minor Changes` for that version. `.github/workflows/release.yml` falls back to `No release summary available.` in the GitHub Release body when the key is missing, which is what tipped this off.

Since `keep_fragments: false` means the `3.1.0` fragments are already consumed, a new fragment in `changelogs/fragments/` would only attach to the next release, not backfill this one. Instead this adds `release_summary` directly under the existing `3.1.0` entry in `changelogs/changelog.yaml` and regenerates `CHANGELOG.rst` from it with `antsibull-changelog generate`.

## Testing

- `antsibull-changelog lint` passes.
- `antsibull-changelog generate` diff is scoped to the new `Release Summary` section under `v3.1.0`, no other content changed.

<!--:robot:-->